### PR TITLE
Major overhaul: Automate mappings with status platforms

### DIFF
--- a/data/CSP.json
+++ b/data/CSP.json
@@ -1,16 +1,40 @@
 {
   "statusref": {
-    "caniuse": "contentsecuritypolicy2",
-    "chrome": 4957003285790720,
-    "edge": "Content Security Policy Level 2",
-    "webkit": "specification-content-security-policy-level-2"
+    "caniuse": [
+      {
+        "id": "contentsecuritypolicy2",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 4957003285790720,
+        "representative": true
+      }
+    ],
+    "webkit": [
+      {
+        "id": "specification-content-security-policy-level-2",
+        "representative": true
+      }
+    ],
+    "bcd": [
+      {
+        "id": "api.SecurityPolicyViolationEvent"
+      }
+    ]
   },
   "features": {
     "securityPolicyViolation": {
       "url": "https://w3c.github.io/webappsec-csp/#securitypolicyviolationevent-interface",
       "title": "SecurityPolicyViolation event",
       "statusref": {
-        "bcd": "api.SecurityPolicyViolationEvent"
+        "bcd": [
+          {
+            "id": "api.SecurityPolicyViolationEvent",
+            "representative": true
+          }
+        ]
       }
     }
   }

--- a/data/IndexedDB.json
+++ b/data/IndexedDB.json
@@ -1,8 +1,22 @@
 {
   "statusref": {
-    "caniuse": "indexeddb2",
-    "chrome": 5812621622116352,
-    "edge": "IndexedDB",
-    "webkit": "specification-indexed-database-2.0"
+    "caniuse": [
+      {
+        "id": "indexeddb2",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5812621622116352,
+        "representative": true
+      }
+    ],
+    "webkit": [
+      {
+        "id": "specification-indexed-database-2.0",
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/SRI.json
+++ b/data/SRI.json
@@ -1,8 +1,22 @@
 {
   "statusref": {
-    "caniuse": "subresource-integrity",
-    "chrome": 6183089948590080,
-    "edge": "Subresource Integrity",
-    "webkit": "feature-subresource-integrity"
+    "caniuse": [
+      {
+        "id": "subresource-integrity",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 6183089948590080,
+        "representative": true
+      }
+    ],
+    "webkit": [
+      {
+        "id": "feature-subresource-integrity",
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/WOFF.json
+++ b/data/WOFF.json
@@ -1,6 +1,10 @@
 {
   "statusref": {
-    "caniuse": "woff",
-    "edge": "Cross-Domain Font Loading"
+    "caniuse": [
+      {
+        "id": "woff",
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/WebCryptoAPI.json
+++ b/data/WebCryptoAPI.json
@@ -1,9 +1,28 @@
 {
   "statusref": {
-    "bcd": "api.Window.crypto",
-    "caniuse": "cryptography",
-    "chrome": 5030265697075200,
-    "edge": "Web Crypto API",
-    "webkit": "specification-web-cryptography-api"
+    "bcd": [
+      {
+        "id": "api.Window.crypto",
+        "representative": true
+      }
+    ],
+    "caniuse": [
+      {
+        "id": "cryptography",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5030265697075200,
+        "representative": true
+      }
+    ],
+    "webkit": [
+      {
+        "id": "specification-web-cryptography-api",
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/accelerometer.json
+++ b/data/accelerometer.json
@@ -1,7 +1,17 @@
 {
   "statusref": {
-    "caniuse": "accelerometer",
-    "chrome": 5698781827825664
+    "caniuse": [
+      {
+        "id": "accelerometer",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5698781827825664,
+        "representative": true
+      }
+    ]
   },
   "polyfills": [
     {

--- a/data/ambient-light.json
+++ b/data/ambient-light.json
@@ -1,9 +1,23 @@
 {
   "statusref": {
-    "bcd": "api.ambientlightsensor",
-    "caniuse": "ambient-light",
-    "chrome": 5298357018820608,
-    "edge": "Ambient Light Sensor API",
+    "bcd": [
+      {
+        "id": "api.ambientlightsensor",
+        "representative": true
+      }
+    ],
+    "caniuse": [
+      {
+        "id": "ambient-light",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5298357018820608,
+        "representative": true
+      }
+    ],
     "manual": [
       {
         "ua": "firefox",

--- a/data/appmanifest.json
+++ b/data/appmanifest.json
@@ -1,43 +1,98 @@
 {
   "statusref": {
-    "caniuse": "web-app-manifest",
-    "chrome": 6488656873259008,
-    "webkit": "specification-web-app-manifest"
+    "caniuse": [
+      {
+        "id": "web-app-manifest",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 6488656873259008,
+        "representative": true
+      },
+      {
+        "id": 5651543017652224
+      },
+      {
+        "id": 5674968658477056
+      },
+      {
+        "id": 6690807302062080
+      },
+      {
+        "id": 4754986680451072
+      },
+      {
+        "id": 5709006190411776
+      }
+    ],
+    "webkit": [
+      {
+        "id": "specification-web-app-manifest",
+        "representative": true
+      }
+    ]
   },
   "features": {
     "background_color": {
       "url": "https://w3c.github.io/manifest/#background_color-member",
       "title": "background_color member",
       "statusref": {
-        "chrome": 5651543017652224
+        "chrome": [
+          {
+            "id": 5651543017652224,
+            "representative": true
+          }
+        ]
       }
     },
     "install": {
       "url": "https://w3c.github.io/manifest/#installation-events",
       "title": "Installation events",
       "statusref": {
-        "chrome": 5674968658477056
+        "chrome": [
+          {
+            "id": 5674968658477056,
+            "representative": true
+          }
+        ]
       }
     },
     "purpose": {
       "url": "https://w3c.github.io/manifest/#purpose-member",
       "title": "purpose member",
       "statusref": {
-        "chrome": 6690807302062080
+        "chrome": [
+          {
+            "id": 6690807302062080,
+            "representative": true
+          }
+        ]
       }
     },
     "related_applications": {
       "url": "https://w3c.github.io/manifest/#related_applications-member",
       "title": "related_applications member",
       "statusref": {
-        "chrome": 4754986680451072
+        "chrome": [
+          {
+            "id": 4754986680451072,
+            "representative": true
+          }
+        ]
       }
     },
     "theme_color": {
       "url": "https://w3c.github.io/manifest/#theme_color-member",
       "title": "theme_color member",
       "statusref": {
-        "chrome": 5709006190411776
+        "chrome": [
+          {
+            "id": 5709006190411776,
+            "representative": true
+          }
+        ]
       }
     }
   }

--- a/data/audio-output.json
+++ b/data/audio-output.json
@@ -1,21 +1,43 @@
 {
   "statusref": {
-    "chrome": 4621603249848320,
-    "edge": "Audio Output Devices API"
+    "chrome": [
+      {
+        "id": 4621603249848320,
+        "representative": true
+      }
+    ],
+    "bcd": [
+      {
+        "id": "api.HTMLMediaElement.sinkId"
+      },
+      {
+        "id": "api.HTMLMediaElement.setSinkId"
+      }
+    ]
   },
   "features": {
     "sinkId": {
       "url": "https://w3c.github.io/mediacapture-output/#dom-htmlmediaelement-sinkid",
       "title": "ID of the audio device",
       "statusref": {
-        "bcd": "api.HTMLMediaElement.sinkId"
+        "bcd": [
+          {
+            "id": "api.HTMLMediaElement.sinkId",
+            "representative": true
+          }
+        ]
       }
     },
     "setSinkId": {
       "url": "https://w3c.github.io/mediacapture-output/#dom-htmlmediaelement-setsinkid",
       "title": "Method to set the ID of the audio device",
       "statusref": {
-        "bcd": "api.HTMLMediaElement.setSinkId"
+        "bcd": [
+          {
+            "id": "api.HTMLMediaElement.setSinkId",
+            "representative": true
+          }
+        ]
       }
     }
   }

--- a/data/background-fetch.json
+++ b/data/background-fetch.json
@@ -1,5 +1,10 @@
 {
   "statusref": {
-    "chrome": 5712608971718656
+    "chrome": [
+      {
+        "id": 5712608971718656,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/background-sync.json
+++ b/data/background-sync.json
@@ -1,8 +1,22 @@
 {
   "statusref": {
-    "bcd": "api.SyncManager",
-    "caniuse": "background-sync",
-    "chrome": 6170807885627392,
-    "edge": "Background Sync API"
+    "bcd": [
+      {
+        "id": "api.SyncManager",
+        "representative": true
+      }
+    ],
+    "caniuse": [
+      {
+        "id": "background-sync",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 6170807885627392,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/badging.json
+++ b/data/badging.json
@@ -1,5 +1,10 @@
 {
   "statusref": {
-    "chrome": 6068482055602176
+    "chrome": [
+      {
+        "id": 6068482055602176,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/battery-status.json
+++ b/data/battery-status.json
@@ -1,9 +1,28 @@
 {
   "statusref": {
-    "bcd": "api.BatteryManager",
-    "caniuse": "battery-status",
-    "chrome": 4537134732017664,
-    "edge": "Battery Status API",
-    "webkit": "specification-battery-status-api"
+    "bcd": [
+      {
+        "id": "api.BatteryManager",
+        "representative": true
+      }
+    ],
+    "caniuse": [
+      {
+        "id": "battery-status",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 4537134732017664,
+        "representative": true
+      }
+    ],
+    "webkit": [
+      {
+        "id": "specification-battery-status-api",
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/beacon.json
+++ b/data/beacon.json
@@ -1,9 +1,28 @@
 {
   "statusref": {
-    "bcd": "api.Navigator.sendBeacon",
-    "caniuse": "beacon",
-    "chrome": 5517433905348608,
-    "edge": "Beacon",
-    "webkit": "specification-beacon-api"
+    "bcd": [
+      {
+        "id": "api.Navigator.sendBeacon",
+        "representative": true
+      }
+    ],
+    "caniuse": [
+      {
+        "id": "beacon",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5517433905348608,
+        "representative": true
+      }
+    ],
+    "webkit": [
+      {
+        "id": "specification-beacon-api",
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/clipboard-apis.json
+++ b/data/clipboard-apis.json
@@ -1,5 +1,10 @@
 {
   "statusref": {
-    "chrome": 5861289330999296
+    "chrome": [
+      {
+        "id": 5861289330999296,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/cookie-store.json
+++ b/data/cookie-store.json
@@ -1,5 +1,10 @@
 {
   "statusref": {
-    "chrome": 5658847691669504
+    "chrome": [
+      {
+        "id": 5658847691669504,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/credential-management.json
+++ b/data/credential-management.json
@@ -1,22 +1,49 @@
 {
   "statusref": {
-    "caniuse": "credential-management",
-    "chrome": 5026422640869376,
-    "edge": "Credential Management API"
+    "caniuse": [
+      {
+        "id": "credential-management",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5026422640869376,
+        "representative": true
+      }
+    ],
+    "bcd": [
+      {
+        "id": "api.Credential"
+      },
+      {
+        "id": "api.Navigator.credentials"
+      }
+    ]
   },
   "features": {
     "Credential": {
       "url": "https://w3c.github.io/webappsec-credential-management/#the-credential-interface",
       "title": "The Credential interface",
       "statusref": {
-        "bcd": "api.Credential"
+        "bcd": [
+          {
+            "id": "api.Credential",
+            "representative": true
+          }
+        ]
       }
     },
     "credentials": {
       "url": "https://w3c.github.io/webappsec-credential-management/#framework-credential-management",
       "title": "navigator.credentials",
       "statusref": {
-        "bcd": "api.Navigator.credentials"
+        "bcd": [
+          {
+            "id": "api.Navigator.credentials",
+            "representative": true
+          }
+        ]
       }
     }
   }

--- a/data/css-animation-worklet.json
+++ b/data/css-animation-worklet.json
@@ -1,5 +1,10 @@
 {
   "statusref": {
-    "chrome": 5762982487261184
+    "chrome": [
+      {
+        "id": 5762982487261184,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/css-animations.json
+++ b/data/css-animations.json
@@ -1,6 +1,16 @@
 {
   "statusref": {
-    "caniuse": "css-animation",
-    "chrome": 6121990213599232
+    "caniuse": [
+      {
+        "id": "css-animation",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 6121990213599232,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/css-backgrounds.json
+++ b/data/css-backgrounds.json
@@ -1,6 +1,16 @@
 {
   "statusref": {
-    "bcd": "css.properties.background.multiple_backgrounds",
-    "caniuse": "multibackgrounds"
+    "bcd": [
+      {
+        "id": "css.properties.background.multiple_backgrounds",
+        "representative": true
+      }
+    ],
+    "caniuse": [
+      {
+        "id": "multibackgrounds",
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/css-break.json
+++ b/data/css-break.json
@@ -4,23 +4,61 @@
       "url": "https://drafts.csswg.org/css-break/#break-decoration",
       "title": "box-decoration-break property",
       "statusref": {
-        "caniuse": "css-boxdecorationbreak"
+        "caniuse": [
+          {
+            "id": "css-boxdecorationbreak",
+            "representative": true
+          }
+        ]
       }
     },
     "page-break": {
       "url": "https://drafts.csswg.org/css-break/#break-between",
       "title": "Page break properties",
       "statusref": {
-        "caniuse": "css-page-break",
-        "chrome": 5630943616303104
+        "caniuse": [
+          {
+            "id": "css-page-break",
+            "representative": true
+          }
+        ],
+        "chrome": [
+          {
+            "id": 5630943616303104,
+            "representative": true
+          }
+        ]
       }
     },
     "widows-orphans": {
       "url": "https://drafts.csswg.org/css-break/#widows-orphans",
       "title": "Widows and orphans",
       "statusref": {
-        "caniuse": "css-widows-orphans"
+        "caniuse": [
+          {
+            "id": "css-widows-orphans",
+            "representative": true
+          }
+        ]
       }
     }
+  },
+  "statusref": {
+    "caniuse": [
+      {
+        "id": "css-boxdecorationbreak"
+      },
+      {
+        "id": "css-page-break"
+      },
+      {
+        "id": "css-widows-orphans"
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5630943616303104
+      }
+    ]
   }
 }

--- a/data/css-color.json
+++ b/data/css-color.json
@@ -1,6 +1,30 @@
 {
   "statusref": {
-    "webkit": "specification-css-color-level-4"
+    "webkit": [
+      {
+        "id": "specification-css-color-level-4",
+        "representative": true
+      }
+    ],
+    "bcd": [
+      {
+        "id": "css.properties.color.alpha"
+      },
+      {
+        "id": "css.properties.color.alpha_hexadecimal_notation"
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5656221012983808
+      },
+      {
+        "id": 5124205561511936
+      },
+      {
+        "id": 5685348285808640
+      }
+    ]
   },
   "features": {
     "icc-colors": {
@@ -11,24 +35,54 @@
       "url": "https://drafts.csswg.org/css-color/#the-hsl-notation",
       "title": "hsl/hsla syntax",
       "statusref": {
-        "bcd": "css.properties.color.alpha",
-        "chrome": 5656221012983808
+        "bcd": [
+          {
+            "id": "css.properties.color.alpha",
+            "representative": true
+          }
+        ],
+        "chrome": [
+          {
+            "id": 5656221012983808,
+            "representative": true
+          }
+        ]
       }
     },
     "rgba": {
       "url": "https://drafts.csswg.org/css-color/#rgb-functions",
       "title": "rgb/rgba syntax",
       "statusref": {
-        "bcd": "css.properties.color.alpha",
-        "chrome": 5124205561511936
+        "bcd": [
+          {
+            "id": "css.properties.color.alpha",
+            "representative": true
+          }
+        ],
+        "chrome": [
+          {
+            "id": 5124205561511936,
+            "representative": true
+          }
+        ]
       }
     },
     "rgba-hex": {
       "url": "https://drafts.csswg.org/css-color/#hex-notation",
       "title": "RGBA hexadecimal notation",
       "statusref": {
-        "bcd": "css.properties.color.alpha_hexadecimal_notation",
-        "chrome": 5685348285808640
+        "bcd": [
+          {
+            "id": "css.properties.color.alpha_hexadecimal_notation",
+            "representative": true
+          }
+        ],
+        "chrome": [
+          {
+            "id": 5685348285808640,
+            "representative": true
+          }
+        ]
       }
     }
   }

--- a/data/css-contain.json
+++ b/data/css-contain.json
@@ -1,7 +1,16 @@
 {
   "statusref": {
-    "caniuse": "css-containment",
-    "chrome": 6522186978295808,
-    "edge": "CSS Containment"
+    "caniuse": [
+      {
+        "id": "css-containment",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 6522186978295808,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/css-content.json
+++ b/data/css-content.json
@@ -1,5 +1,10 @@
 {
   "statusref": {
-    "bcd": "css.properties.content"
+    "bcd": [
+      {
+        "id": "css.properties.content",
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/css-device-adapt.json
+++ b/data/css-device-adapt.json
@@ -1,8 +1,22 @@
 {
   "statusref": {
-    "bcd": "css.at-rules.viewport",
-    "caniuse": "css-deviceadaptation",
-    "chrome": 4737164243894272,
-    "edge": "CSS Device Adaptation"
+    "bcd": [
+      {
+        "id": "css.at-rules.viewport",
+        "representative": true
+      }
+    ],
+    "caniuse": [
+      {
+        "id": "css-deviceadaptation",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 4737164243894272,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/css-flexbox.json
+++ b/data/css-flexbox.json
@@ -1,7 +1,16 @@
 {
   "statusref": {
-    "caniuse": "flexbox",
-    "chrome": 4837301406400512,
-    "edge": "Flexbox"
+    "caniuse": [
+      {
+        "id": "flexbox",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 4837301406400512,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/css-font-loading.json
+++ b/data/css-font-loading.json
@@ -1,22 +1,49 @@
 {
   "statusref": {
-    "caniuse": "font-loading",
-    "chrome": 6244676289953792,
-    "edge": "CSS Font Loading API"
+    "caniuse": [
+      {
+        "id": "font-loading",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 6244676289953792,
+        "representative": true
+      }
+    ],
+    "bcd": [
+      {
+        "id": "api.FontFace"
+      },
+      {
+        "id": "api.FontFaceSet"
+      }
+    ]
   },
   "features": {
     "FontFace": {
       "url": "https://drafts.csswg.org/css-font-loading/#fontface-interface",
       "title": "FontFace interface",
       "statusref": {
-        "bcd": "api.FontFace"
+        "bcd": [
+          {
+            "id": "api.FontFace",
+            "representative": true
+          }
+        ]
       }
     },
     "FontFaceSet": {
       "url": "https://drafts.csswg.org/css-font-loading/#FontFaceSet-interface",
       "title": "FontFaceSet interface",
       "statusref": {
-        "bcd": "api.FontFaceSet"
+        "bcd": [
+          {
+            "id": "api.FontFaceSet",
+            "representative": true
+          }
+        ]
       }
     }
   }

--- a/data/css-fonts.json
+++ b/data/css-fonts.json
@@ -4,41 +4,122 @@
       "url": "https://drafts.csswg.org/css-fonts-4/#font-variation-props",
       "title": "Variable fonts",
       "statusref": {
-        "caniuse": "variable-fonts",
-        "chrome": 4708676673732608,
-        "edge": "Font Variation Properties with OpenType Variable Font Support",
-        "webkit": "feature-variation-fonts"
+        "caniuse": [
+          {
+            "id": "variable-fonts",
+            "representative": true
+          }
+        ],
+        "chrome": [
+          {
+            "id": 4708676673732608,
+            "representative": true
+          }
+        ],
+        "webkit": [
+          {
+            "id": "feature-variation-fonts",
+            "representative": true
+          }
+        ]
       }
     },
     "font-variant-caps": {
       "url": "https://drafts.csswg.org/css-fonts-4/#font-variant-caps-prop",
       "title": "font-variant-caps property",
       "statusref": {
-        "bcd": "css.properties.font-variant-caps",
-        "chrome": 5764191470223360
+        "bcd": [
+          {
+            "id": "css.properties.font-variant-caps",
+            "representative": true
+          }
+        ],
+        "chrome": [
+          {
+            "id": 5764191470223360,
+            "representative": true
+          }
+        ]
       }
     },
     "font-variant-numeric": {
       "url": "https://drafts.csswg.org/css-fonts-4/#font-variant-numeric-prop",
       "title": "font-variant-numeric property",
       "statusref": {
-        "bcd": "css.properties.font-variant-numeric",
-        "chrome": 5716551491649536
+        "bcd": [
+          {
+            "id": "css.properties.font-variant-numeric",
+            "representative": true
+          }
+        ],
+        "chrome": [
+          {
+            "id": 5716551491649536,
+            "representative": true
+          }
+        ]
       }
     },
     "font-stretch": {
       "url": "https://drafts.csswg.org/css-fonts-4/#font-stretch-prop",
       "title": "font-stretch property",
       "statusref": {
-        "bcd": "css.properties.font-stretch"
+        "bcd": [
+          {
+            "id": "css.properties.font-stretch",
+            "representative": true
+          }
+        ]
       }
     },
     "font-synthesis": {
       "url": "https://drafts.csswg.org/css-fonts-4/#font-synthesis-prop",
       "title": "font-synthesis property",
       "statusref": {
-        "bcd": "css.properties.font-synthesis"
+        "bcd": [
+          {
+            "id": "css.properties.font-synthesis",
+            "representative": true
+          }
+        ]
       }
     }
+  },
+  "statusref": {
+    "caniuse": [
+      {
+        "id": "variable-fonts"
+      }
+    ],
+    "chrome": [
+      {
+        "id": 4708676673732608
+      },
+      {
+        "id": 5764191470223360
+      },
+      {
+        "id": 5716551491649536
+      }
+    ],
+    "webkit": [
+      {
+        "id": "feature-variation-fonts"
+      }
+    ],
+    "bcd": [
+      {
+        "id": "css.properties.font-variant-caps"
+      },
+      {
+        "id": "css.properties.font-variant-numeric"
+      },
+      {
+        "id": "css.properties.font-stretch"
+      },
+      {
+        "id": "css.properties.font-synthesis"
+      }
+    ]
   }
 }

--- a/data/css-gcpm.json
+++ b/data/css-gcpm.json
@@ -1,6 +1,10 @@
 {
   "statusref": {
-    "chrome": 5400251359821824,
-    "edge": "Generated Content for Paged Media"
+    "chrome": [
+      {
+        "id": 5400251359821824,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/css-grid.json
+++ b/data/css-grid.json
@@ -1,8 +1,22 @@
 {
   "statusref": {
-    "caniuse": "css-grid",
-    "chrome": 4589636412243968,
-    "edge": "CSS Grid Layout",
-    "webkit": "specification-css-grid-layout-level-1"
+    "caniuse": [
+      {
+        "id": "css-grid",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 4589636412243968,
+        "representative": true
+      }
+    ],
+    "webkit": [
+      {
+        "id": "specification-css-grid-layout-level-1",
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/css-overscroll.json
+++ b/data/css-overscroll.json
@@ -1,7 +1,22 @@
 {
   "statusref": {
-    "bcd": "css.properties.overscroll-behavior",
-    "caniuse": "css-overscroll-behavior",
-    "chrome": 5734614437986304
+    "bcd": [
+      {
+        "id": "css.properties.overscroll-behavior",
+        "representative": true
+      }
+    ],
+    "caniuse": [
+      {
+        "id": "css-overscroll-behavior",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5734614437986304,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/css-page.json
+++ b/data/css-page.json
@@ -1,5 +1,10 @@
 {
   "statusref": {
-    "caniuse": "css-paged-media"
+    "caniuse": [
+      {
+        "id": "css-paged-media",
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/css-paint-api.json
+++ b/data/css-paint-api.json
@@ -1,7 +1,22 @@
 {
   "statusref": {
-    "caniuse": "css-paint-api",
-    "chrome": 5685444318593024,
-    "webkit": "specification-css-painting-api-level-1"
+    "caniuse": [
+      {
+        "id": "css-paint-api",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5685444318593024,
+        "representative": true
+      }
+    ],
+    "webkit": [
+      {
+        "id": "specification-css-painting-api-level-1",
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/css-rhythm.json
+++ b/data/css-rhythm.json
@@ -1,13 +1,28 @@
 {
   "statusref": {
-    "webkit": "specification-css-rhythmic-sizing"
+    "webkit": [
+      {
+        "id": "specification-css-rhythmic-sizing",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5734273533345792
+      }
+    ]
   },
   "features": {
     "line-height-step": {
       "url": "https://drafts.csswg.org/css-rhythm/#line-height-step",
       "title": "line-height-step property",
       "statusref": {
-        "chrome": 5734273533345792
+        "chrome": [
+          {
+            "id": 5734273533345792,
+            "representative": true
+          }
+        ]
       }
     }
   }

--- a/data/css-ruby.json
+++ b/data/css-ruby.json
@@ -4,15 +4,35 @@
       "url": "https://drafts.csswg.org/css-ruby-1/#ruby-align-property",
       "title": "The ruby-align property",
       "statusref": {
-        "bcd": "css.properties.ruby-align"
+        "bcd": [
+          {
+            "id": "css.properties.ruby-align",
+            "representative": true
+          }
+        ]
       }
     },
     "ruby-position": {
       "url": "https://drafts.csswg.org/css-ruby-1/#rubypos",
       "title": "The ruby-position property",
       "statusref": {
-        "bcd": "css.properties.ruby-position"
+        "bcd": [
+          {
+            "id": "css.properties.ruby-position",
+            "representative": true
+          }
+        ]
       }
     }
+  },
+  "statusref": {
+    "bcd": [
+      {
+        "id": "css.properties.ruby-align"
+      },
+      {
+        "id": "css.properties.ruby-position"
+      }
+    ]
   }
 }

--- a/data/css-scoping.json
+++ b/data/css-scoping.json
@@ -4,29 +4,65 @@
       "url": "https://drafts.csswg.org/css-scoping/#selectordef-host",
       "title": "The :host pseudo-class",
       "statusref": {
-        "bcd": "css.selectors.host"
+        "bcd": [
+          {
+            "id": "css.selectors.host",
+            "representative": true
+          }
+        ]
       }
     },
     "hostfunction": {
       "url": "https://drafts.csswg.org/css-scoping/#selectordef-host-function",
       "title": "The :host() pseudo-class",
       "statusref": {
-        "bcd": "css.selectors.hostfunction"
+        "bcd": [
+          {
+            "id": "css.selectors.hostfunction",
+            "representative": true
+          }
+        ]
       }
     },
     "host-context": {
       "url": "https://drafts.csswg.org/css-scoping/#selectordef-host-context",
       "title": "The :host-context pseudo-class",
       "statusref": {
-        "bcd": "css.selectors.host-context"
+        "bcd": [
+          {
+            "id": "css.selectors.host-context",
+            "representative": true
+          }
+        ]
       }
     },
     "slotted": {
       "url": "https://drafts.csswg.org/css-scoping/#selectordef-slotted",
       "title": "The ::slotted() pseudo-element",
       "statusref": {
-        "bcd": "css.selectors.slotted"
+        "bcd": [
+          {
+            "id": "css.selectors.slotted",
+            "representative": true
+          }
+        ]
       }
     }
+  },
+  "statusref": {
+    "bcd": [
+      {
+        "id": "css.selectors.host"
+      },
+      {
+        "id": "css.selectors.hostfunction"
+      },
+      {
+        "id": "css.selectors.host-context"
+      },
+      {
+        "id": "css.selectors.slotted"
+      }
+    ]
   }
 }

--- a/data/css-scroll-snap.json
+++ b/data/css-scroll-snap.json
@@ -1,8 +1,22 @@
 {
   "statusref": {
-    "caniuse": "css-snappoints",
-    "chrome": 5721832506261504,
-    "edge": "CSS Scroll Snap Points",
-    "webkit": "specification-css-scroll-snap-points-module-level-1"
+    "caniuse": [
+      {
+        "id": "css-snappoints",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5721832506261504,
+        "representative": true
+      }
+    ],
+    "webkit": [
+      {
+        "id": "specification-css-scroll-snap-points-module-level-1",
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/css-shadow-parts.json
+++ b/data/css-shadow-parts.json
@@ -1,7 +1,22 @@
 {
   "statusref": {
-    "bcd": "css.selectors.part",
-    "chrome": 5763933658939392,
-    "webkit": "specification-css-shadow-parts"
+    "bcd": [
+      {
+        "id": "css.selectors.part",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5763933658939392,
+        "representative": true
+      }
+    ],
+    "webkit": [
+      {
+        "id": "specification-css-shadow-parts",
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/css-size-adjust.json
+++ b/data/css-size-adjust.json
@@ -1,7 +1,22 @@
 {
   "statusref": {
-    "bcd": "css.properties.text-size-adjust",
-    "caniuse": "text-size-adjust",
-    "chrome": 5730156303876096
+    "bcd": [
+      {
+        "id": "css.properties.text-size-adjust",
+        "representative": true
+      }
+    ],
+    "caniuse": [
+      {
+        "id": "text-size-adjust",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5730156303876096,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/css-transforms.json
+++ b/data/css-transforms.json
@@ -1,6 +1,10 @@
 {
   "statusref": {
-    "caniuse": "transforms2d",
-    "edge": "Transforms"
+    "caniuse": [
+      {
+        "id": "transforms2d",
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/css-transitions.json
+++ b/data/css-transitions.json
@@ -1,5 +1,10 @@
 {
   "statusref": {
-    "caniuse": "css-transitions"
+    "caniuse": [
+      {
+        "id": "css-transitions",
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/css-will-change.json
+++ b/data/css-will-change.json
@@ -1,8 +1,22 @@
 {
   "statusref": {
-    "caniuse": "will-change",
-    "chrome": 5954199330226176,
-    "edge": "CSS Will Change",
-    "webkit": "specification-css-will-change"
+    "caniuse": [
+      {
+        "id": "will-change",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5954199330226176,
+        "representative": true
+      }
+    ],
+    "webkit": [
+      {
+        "id": "specification-css-will-change",
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/cssom-view.json
+++ b/data/cssom-view.json
@@ -4,16 +4,46 @@
       "url": "https://drafts.csswg.org/cssom-view/#smooth-scrolling",
       "title": "scroll-behavior property",
       "statusref": {
-        "bcd": "css.properties.scroll-behavior",
-        "caniuse": "css-scroll-behavior"
+        "bcd": [
+          {
+            "id": "css.properties.scroll-behavior",
+            "representative": true
+          }
+        ],
+        "caniuse": [
+          {
+            "id": "css-scroll-behavior",
+            "representative": true
+          }
+        ]
       }
     },
     "getBoundingClientRect": {
       "url": "https://drafts.csswg.org/cssom-view/#dom-element-getboundingclientrect",
       "title": "getBoundingClientRect() method",
       "statusref": {
-        "caniuse": "getboundingclientrect"
+        "caniuse": [
+          {
+            "id": "getboundingclientrect",
+            "representative": true
+          }
+        ]
       }
     }
+  },
+  "statusref": {
+    "bcd": [
+      {
+        "id": "css.properties.scroll-behavior"
+      }
+    ],
+    "caniuse": [
+      {
+        "id": "css-scroll-behavior"
+      },
+      {
+        "id": "getboundingclientrect"
+      }
+    ]
   }
 }

--- a/data/cssom.json
+++ b/data/cssom.json
@@ -4,8 +4,20 @@
       "url": "https://www.w3.org/TR/cssom-1/#create-a-constructed-cssstylesheet",
       "title": "Constructable stylesheets",
       "statusref": {
-        "chrome": 5394843094220800
+        "chrome": [
+          {
+            "id": 5394843094220800,
+            "representative": true
+          }
+        ]
       }
     }
+  },
+  "statusref": {
+    "chrome": [
+      {
+        "id": 5394843094220800
+      }
+    ]
   }
 }

--- a/data/device-memory.json
+++ b/data/device-memory.json
@@ -4,15 +4,35 @@
       "url": "https://w3c.github.io/device-memory/#sec-device-memory-client-hint-header",
       "title": "Header field",
       "statusref": {
-        "chrome": 5741299856572416
+        "chrome": [
+          {
+            "id": 5741299856572416,
+            "representative": true
+          }
+        ]
       }
     },
     "jsapi": {
       "url": "https://w3c.github.io/device-memory/#sec-device-memory-js-api",
       "title": "JS API",
       "statusref": {
-        "chrome": 5119701235531776
+        "chrome": [
+          {
+            "id": 5119701235531776,
+            "representative": true
+          }
+        ]
       }
     }
+  },
+  "statusref": {
+    "chrome": [
+      {
+        "id": 5741299856572416
+      },
+      {
+        "id": 5119701235531776
+      }
+    ]
   }
 }

--- a/data/dom.json
+++ b/data/dom.json
@@ -4,10 +4,42 @@
       "url": "https://dom.spec.whatwg.org/#shadow-trees",
       "title": "Shadow tree",
       "statusref": {
-        "caniuse": "shadowdomv1",
-        "chrome": 4667415417847808,
-        "webkit": "feature-shadow-dom"
+        "caniuse": [
+          {
+            "id": "shadowdomv1",
+            "representative": true
+          }
+        ],
+        "chrome": [
+          {
+            "id": 4667415417847808,
+            "representative": true
+          }
+        ],
+        "webkit": [
+          {
+            "id": "feature-shadow-dom",
+            "representative": true
+          }
+        ]
       }
     }
+  },
+  "statusref": {
+    "caniuse": [
+      {
+        "id": "shadowdomv1"
+      }
+    ],
+    "chrome": [
+      {
+        "id": 4667415417847808
+      }
+    ],
+    "webkit": [
+      {
+        "id": "feature-shadow-dom"
+      }
+    ]
   }
 }

--- a/data/element-timing.json
+++ b/data/element-timing.json
@@ -4,15 +4,35 @@
       "url": "https://wicg.github.io/element-timing/#sec-report-image-element",
       "title": "Support for images",
       "statusref": {
-        "chrome": 6727079454310400
+        "chrome": [
+          {
+            "id": 6727079454310400,
+            "representative": true
+          }
+        ]
       }
     },
     "text": {
       "url": "https://wicg.github.io/element-timing/#sec-report-text",
       "title": "Support for text",
       "statusref": {
-        "chrome": 6230814637424640
+        "chrome": [
+          {
+            "id": 6230814637424640,
+            "representative": true
+          }
+        ]
       }
     }
+  },
+  "statusref": {
+    "chrome": [
+      {
+        "id": 6727079454310400
+      },
+      {
+        "id": 6230814637424640
+      }
+    ]
   }
 }

--- a/data/encrypted-media.json
+++ b/data/encrypted-media.json
@@ -8,19 +8,39 @@
       "url": "https://w3c.github.io/encrypted-media/d",
       "title": "HDCP detection",
       "statusref": {
-        "chrome": 5652917147140096
+        "chrome": [
+          {
+            "id": 5652917147140096,
+            "representative": true
+          }
+        ]
       }
     },
     "encryption-scheme": {
       "url": "https://w3c.github.io/encrypted-media/d",
       "title": "Encryption scheme detection",
       "statusref": {
-        "chrome": 5184416120832000
+        "chrome": [
+          {
+            "id": 5184416120832000,
+            "representative": true
+          }
+        ]
       }
     },
     "find-existing-sessions": {
       "url": "https://w3c.github.io/encrypted-media/n",
       "title": "API to find existing sessions"
     }
+  },
+  "statusref": {
+    "chrome": [
+      {
+        "id": 5652917147140096
+      },
+      {
+        "id": 5184416120832000
+      }
+    ]
   }
 }

--- a/data/event-timing.json
+++ b/data/event-timing.json
@@ -1,5 +1,10 @@
 {
   "statusref": {
-    "chrome": 5167290693713920
+    "chrome": [
+      {
+        "id": 5167290693713920,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/fetch.json
+++ b/data/fetch.json
@@ -1,9 +1,23 @@
 {
   "statusref": {
-    "caniuse": "fetch",
-    "chrome": 6730533392351232,
-    "edge": "Fetch API",
-    "webkit": "specification-fetch"
+    "caniuse": [
+      {
+        "id": "fetch",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 6730533392351232,
+        "representative": true
+      }
+    ],
+    "webkit": [
+      {
+        "id": "specification-fetch",
+        "representative": true
+      }
+    ]
   },
   "features": {
     "cors": {

--- a/data/file-system-access.json
+++ b/data/file-system-access.json
@@ -1,5 +1,10 @@
 {
   "statusref": {
-    "chrome": 6284708426022912
+    "chrome": [
+      {
+        "id": 6284708426022912,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/fullscreen.json
+++ b/data/fullscreen.json
@@ -1,7 +1,16 @@
 {
   "statusref": {
-    "caniuse": "fullscreen",
-    "chrome": 5259513871466496,
-    "edge": "Fullscreen API"
+    "caniuse": [
+      {
+        "id": "fullscreen",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5259513871466496,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/gamepad.json
+++ b/data/gamepad.json
@@ -1,8 +1,22 @@
 {
   "statusref": {
-    "caniuse": "gamepad",
-    "chrome": 5118776383111168,
-    "edge": "GamePad API",
-    "webkit": "specification-gamepad"
+    "caniuse": [
+      {
+        "id": "gamepad",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5118776383111168,
+        "representative": true
+      }
+    ],
+    "webkit": [
+      {
+        "id": "specification-gamepad",
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/geolocation.json
+++ b/data/geolocation.json
@@ -1,8 +1,22 @@
 {
   "statusref": {
-    "caniuse": "geolocation",
-    "chrome": 6348855016685568,
-    "edge": "Geolocation",
-    "webkit": "specification-geolocation-api"
+    "caniuse": [
+      {
+        "id": "geolocation",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 6348855016685568,
+        "representative": true
+      }
+    ],
+    "webkit": [
+      {
+        "id": "specification-geolocation-api",
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/gyroscope.json
+++ b/data/gyroscope.json
@@ -1,7 +1,17 @@
 {
   "statusref": {
-    "caniuse": "gyroscope",
-    "chrome": 5698781827825664
+    "caniuse": [
+      {
+        "id": "gyroscope",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5698781827825664,
+        "representative": true
+      }
+    ]
   },
   "polyfills": [
     {

--- a/data/hr-time.json
+++ b/data/hr-time.json
@@ -1,8 +1,22 @@
 {
   "statusref": {
-    "bcd": "api.Performance",
-    "caniuse": "high-resolution-time",
-    "chrome": 5349124069130240,
-    "edge": "High Resolution Time"
+    "bcd": [
+      {
+        "id": "api.Performance",
+        "representative": true
+      }
+    ],
+    "caniuse": [
+      {
+        "id": "high-resolution-time",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5349124069130240,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/html-media-capture.json
+++ b/data/html-media-capture.json
@@ -1,5 +1,10 @@
 {
   "statusref": {
-    "caniuse": "html-media-capture"
+    "caniuse": [
+      {
+        "id": "html-media-capture",
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/html.json
+++ b/data/html.json
@@ -4,206 +4,617 @@
       "url": "https://html.spec.whatwg.org/multipage/#the-template-element",
       "title": "The template element",
       "statusref": {
-        "bcd": "html.elements.template",
-        "caniuse": "template-literals",
-        "chrome": 5207287069147136
+        "bcd": [
+          {
+            "id": "html.elements.template",
+            "representative": true
+          }
+        ],
+        "caniuse": [
+          {
+            "id": "template-literals",
+            "representative": true
+          }
+        ],
+        "chrome": [
+          {
+            "id": 5207287069147136,
+            "representative": true
+          }
+        ]
       }
     },
     "custom-elements": {
       "url": "https://html.spec.whatwg.org/multipage/#custom-elements",
       "title": "Custom elements",
       "statusref": {
-        "caniuse": "custom-elementsv1",
-        "chrome": 4696261944934400
+        "caniuse": [
+          {
+            "id": "custom-elementsv1",
+            "representative": true
+          }
+        ],
+        "chrome": [
+          {
+            "id": 4696261944934400,
+            "representative": true
+          }
+        ]
       }
     },
     "js-module": {
       "url": "https://html.spec.whatwg.org/multipage/#integration-with-the-javascript-module-system",
       "title": "Integration with the JavaScript module system",
       "statusref": {
-        "bcd": "html.elements.script.type.module",
-        "caniuse": "es6-module"
+        "bcd": [
+          {
+            "id": "html.elements.script.type.module",
+            "representative": true
+          }
+        ],
+        "caniuse": [
+          {
+            "id": "es6-module",
+            "representative": true
+          }
+        ]
       }
     },
     "2dcontext": {
       "url": "https://html.spec.whatwg.org/multipage/#2dcontext",
       "title": "The 2D rendering context",
       "statusref": {
-        "bcd": "api.CanvasRenderingContext2D",
-        "caniuse": "canvas",
-        "chrome": 5100084685438976,
-        "edge": "Canvas"
+        "bcd": [
+          {
+            "id": "api.CanvasRenderingContext2D",
+            "representative": true
+          }
+        ],
+        "caniuse": [
+          {
+            "id": "canvas",
+            "representative": true
+          }
+        ],
+        "chrome": [
+          {
+            "id": 5100084685438976,
+            "representative": true
+          }
+        ]
       }
     },
     "ruby": {
       "url": "https://html.spec.whatwg.org/multipage/#the-ruby-element",
       "title": "The ruby element",
       "statusref": {
-        "caniuse": "ruby"
+        "caniuse": [
+          {
+            "id": "ruby",
+            "representative": true
+          }
+        ]
       }
     },
     "animation-frames": {
       "url": "https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#animation-frames",
       "title": "requestAnimationFrame",
       "statusref": {
-        "bcd": "api.Window.requestAnimationFrame",
-        "caniuse": "requestanimationframe",
-        "chrome": 5233400470306816,
-        "edge": "requestAnimationFrame()"
+        "bcd": [
+          {
+            "id": "api.Window.requestAnimationFrame",
+            "representative": true
+          }
+        ],
+        "caniuse": [
+          {
+            "id": "requestanimationframe",
+            "representative": true
+          }
+        ],
+        "chrome": [
+          {
+            "id": 5233400470306816,
+            "representative": true
+          }
+        ]
       }
     },
     "audio": {
       "url": "https://html.spec.whatwg.org/multipage/media.html#the-audio-element",
       "title": "audio element",
       "statusref": {
-        "bcd": "api.HTMLAudioElement",
-        "caniuse": "audio"
+        "bcd": [
+          {
+            "id": "api.HTMLAudioElement",
+            "representative": true
+          }
+        ],
+        "caniuse": [
+          {
+            "id": "audio",
+            "representative": true
+          }
+        ]
       }
     },
     "datalist": {
       "url": "https://html.spec.whatwg.org/multipage/form-elements.html#the-datalist-element",
       "title": "datalist element",
       "statusref": {
-        "bcd": "html.elements.datalist",
-        "caniuse": "datalist",
-        "chrome": 6090950820495360,
-        "edge": "<datalist> Element"
+        "bcd": [
+          {
+            "id": "html.elements.datalist",
+            "representative": true
+          }
+        ],
+        "caniuse": [
+          {
+            "id": "datalist",
+            "representative": true
+          }
+        ],
+        "chrome": [
+          {
+            "id": 6090950820495360,
+            "representative": true
+          }
+        ]
       }
     },
     "html5-download": {
       "url": "https://html.spec.whatwg.org/multipage/links.html#downloading-resources",
       "title": "download attribute",
       "statusref": {
-        "bcd": "api.HTMLAnchorElement.download",
-        "caniuse": "download",
-        "chrome": 6473924464345088,
-        "edge": "a[download] attribute",
-        "webkit": "feature-download-attribute"
+        "bcd": [
+          {
+            "id": "api.HTMLAnchorElement.download",
+            "representative": true
+          }
+        ],
+        "caniuse": [
+          {
+            "id": "download",
+            "representative": true
+          }
+        ],
+        "chrome": [
+          {
+            "id": 6473924464345088,
+            "representative": true
+          }
+        ],
+        "webkit": [
+          {
+            "id": "feature-download-attribute",
+            "representative": true
+          }
+        ]
       }
     },
     "html5-sandbox": {
       "url": "https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-sandbox",
       "title": "sandbox iframe attribute",
       "statusref": {
-        "bcd": "api.HTMLIFrameElement.sandbox",
-        "caniuse": "iframe-sandbox",
-        "chrome": 5715536319086592,
-        "edge": "iframe[sandbox] attribute"
+        "bcd": [
+          {
+            "id": "api.HTMLIFrameElement.sandbox",
+            "representative": true
+          }
+        ],
+        "caniuse": [
+          {
+            "id": "iframe-sandbox",
+            "representative": true
+          }
+        ],
+        "chrome": [
+          {
+            "id": 5715536319086592,
+            "representative": true
+          }
+        ]
       }
     },
     "htmlmediaelement": {
       "url": "https://html.spec.whatwg.org/multipage/media.html#media-elements",
       "title": "HTMLMediaElement interface",
       "statusref": {
-        "bcd": "api.HTMLMediaElement",
-        "caniuse": "video"
+        "bcd": [
+          {
+            "id": "api.HTMLMediaElement",
+            "representative": true
+          }
+        ],
+        "caniuse": [
+          {
+            "id": "video",
+            "representative": true
+          }
+        ]
       }
     },
     "inputdate": {
       "url": "https://html.spec.whatwg.org/multipage/input.html#date-state-(type=date)",
       "title": "Date and time input types",
       "statusref": {
-        "caniuse": "input-datetime",
-        "chrome": 6640933999214592
+        "caniuse": [
+          {
+            "id": "input-datetime",
+            "representative": true
+          }
+        ],
+        "chrome": [
+          {
+            "id": 6640933999214592,
+            "representative": true
+          }
+        ]
       }
     },
     "inputhint": {
       "url": "https://html.spec.whatwg.org/multipage/input.html#the-placeholder-attribute",
       "title": "input placeholder attribute",
       "statusref": {
-        "caniuse": "input-placeholder"
+        "caniuse": [
+          {
+            "id": "input-placeholder",
+            "representative": true
+          }
+        ]
       }
     },
     "inputpattern": {
       "url": "https://html.spec.whatwg.org/multipage/input.html#the-pattern-attribute",
       "title": "pattern attribute for input fields",
       "statusref": {
-        "caniuse": "input-pattern"
+        "caniuse": [
+          {
+            "id": "input-pattern",
+            "representative": true
+          }
+        ]
       }
     },
     "inputtext": {
       "url": "https://html.spec.whatwg.org/multipage/input.html#e-mail-state-(type=email)",
       "title": "tel, email, url input types",
       "statusref": {
-        "caniuse": "input-email-tel-url"
+        "caniuse": [
+          {
+            "id": "input-email-tel-url",
+            "representative": true
+          }
+        ]
       }
     },
     "offscreencanvas": {
       "url": "https://html.spec.whatwg.org/multipage/canvas.html#the-offscreencanvas-interface",
       "title": "OffscreenCanvas",
       "statusref": {
-        "bcd": "api.OffscreenCanvas",
-        "caniuse": "offscreencanvas",
-        "chrome": 5681560598609920
+        "bcd": [
+          {
+            "id": "api.OffscreenCanvas",
+            "representative": true
+          }
+        ],
+        "caniuse": [
+          {
+            "id": "offscreencanvas",
+            "representative": true
+          }
+        ],
+        "chrome": [
+          {
+            "id": 5681560598609920,
+            "representative": true
+          }
+        ]
       }
     },
     "online": {
       "url": "https://html.spec.whatwg.org/multipage/offline.html#navigator.online",
       "title": "onLine DOM flag",
       "statusref": {
-        "caniuse": "online-status"
+        "caniuse": [
+          {
+            "id": "online-status",
+            "representative": true
+          }
+        ]
       }
     },
     "page-visibility": {
       "url": "https://html.spec.whatwg.org/multipage/interaction.html#page-visibility",
       "title": "Page visibility",
       "statusref": {
-        "caniuse": "pagevisibility",
-        "chrome": 5689697795833856,
-        "edge": "Page Visibility API"
+        "caniuse": [
+          {
+            "id": "pagevisibility",
+            "representative": true
+          }
+        ],
+        "chrome": [
+          {
+            "id": 5689697795833856,
+            "representative": true
+          }
+        ]
       }
     },
     "picture": {
       "url": "https://html.spec.whatwg.org/multipage/embedded-content.html#the-picture-element",
       "title": "picture element",
       "statusref": {
-        "bcd": "html.elements.picture",
-        "caniuse": "picture",
-        "chrome": 5910974510923776,
-        "edge": "<picture> Element",
-        "webkit": "feature-picture-element"
+        "bcd": [
+          {
+            "id": "html.elements.picture",
+            "representative": true
+          }
+        ],
+        "caniuse": [
+          {
+            "id": "picture",
+            "representative": true
+          }
+        ],
+        "chrome": [
+          {
+            "id": 5910974510923776,
+            "representative": true
+          }
+        ],
+        "webkit": [
+          {
+            "id": "feature-picture-element",
+            "representative": true
+          }
+        ]
       }
     },
     "preload": {
       "url": "https://html.spec.whatwg.org/multipage/links.html#link-type-preload",
       "title": "Link type \"preload\"",
       "statusref": {
-        "caniuse": "link-rel-preload",
-        "chrome": 5757468554559488,
-        "edge": "Preload",
-        "webkit": "specification-preload"
+        "caniuse": [
+          {
+            "id": "link-rel-preload",
+            "representative": true
+          }
+        ],
+        "chrome": [
+          {
+            "id": 5757468554559488,
+            "representative": true
+          }
+        ],
+        "webkit": [
+          {
+            "id": "specification-preload",
+            "representative": true
+          }
+        ]
       }
     },
     "srcset": {
       "url": "https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-srcset",
       "title": "srcset attribute",
       "statusref": {
-        "caniuse": "srcset",
-        "chrome": 4644337115725824,
-        "edge": "<img srcset>",
-        "webkit": "feature-srcset-w-descriptor-and-related-sizes-attribute"
+        "caniuse": [
+          {
+            "id": "srcset",
+            "representative": true
+          }
+        ],
+        "chrome": [
+          {
+            "id": 4644337115725824,
+            "representative": true
+          }
+        ],
+        "webkit": [
+          {
+            "id": "feature-srcset-w-descriptor-and-related-sizes-attribute",
+            "representative": true
+          }
+        ]
       }
     },
     "timeupdate": {
       "url": "https://html.spec.whatwg.org/multipage/media.html#event-media-timeupdate",
       "title": "timeupdate event",
       "statusref": {
-        "caniuse": "video"
+        "caniuse": [
+          {
+            "id": "video",
+            "representative": true
+          }
+        ]
       }
     },
     "video": {
       "url": "https://html.spec.whatwg.org/multipage/media.html#the-video-element",
       "title": "video element",
       "statusref": {
-        "caniuse": "video"
+        "caniuse": [
+          {
+            "id": "video",
+            "representative": true
+          }
+        ]
       }
     },
     "webworkers": {
       "url": "https://html.spec.whatwg.org/multipage/workers.html",
       "title": "Web workers",
       "statusref": {
-        "caniuse": "webworkers"
+        "caniuse": [
+          {
+            "id": "webworkers",
+            "representative": true
+          }
+        ]
       }
     }
+  },
+  "statusref": {
+    "bcd": [
+      {
+        "id": "html.elements.template"
+      },
+      {
+        "id": "html.elements.script.type.module"
+      },
+      {
+        "id": "api.CanvasRenderingContext2D"
+      },
+      {
+        "id": "api.Window.requestAnimationFrame"
+      },
+      {
+        "id": "api.HTMLAudioElement"
+      },
+      {
+        "id": "html.elements.datalist"
+      },
+      {
+        "id": "api.HTMLAnchorElement.download"
+      },
+      {
+        "id": "api.HTMLIFrameElement.sandbox"
+      },
+      {
+        "id": "api.HTMLMediaElement"
+      },
+      {
+        "id": "api.OffscreenCanvas"
+      },
+      {
+        "id": "html.elements.picture"
+      }
+    ],
+    "caniuse": [
+      {
+        "id": "template-literals"
+      },
+      {
+        "id": "custom-elementsv1"
+      },
+      {
+        "id": "es6-module"
+      },
+      {
+        "id": "canvas"
+      },
+      {
+        "id": "ruby"
+      },
+      {
+        "id": "requestanimationframe"
+      },
+      {
+        "id": "audio"
+      },
+      {
+        "id": "datalist"
+      },
+      {
+        "id": "download"
+      },
+      {
+        "id": "iframe-sandbox"
+      },
+      {
+        "id": "video"
+      },
+      {
+        "id": "input-datetime"
+      },
+      {
+        "id": "input-placeholder"
+      },
+      {
+        "id": "input-pattern"
+      },
+      {
+        "id": "input-email-tel-url"
+      },
+      {
+        "id": "offscreencanvas"
+      },
+      {
+        "id": "online-status"
+      },
+      {
+        "id": "pagevisibility"
+      },
+      {
+        "id": "picture"
+      },
+      {
+        "id": "link-rel-preload"
+      },
+      {
+        "id": "srcset"
+      },
+      {
+        "id": "webworkers"
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5207287069147136
+      },
+      {
+        "id": 4696261944934400
+      },
+      {
+        "id": 5100084685438976
+      },
+      {
+        "id": 5233400470306816
+      },
+      {
+        "id": 6090950820495360
+      },
+      {
+        "id": 6473924464345088
+      },
+      {
+        "id": 5715536319086592
+      },
+      {
+        "id": 6640933999214592
+      },
+      {
+        "id": 5681560598609920
+      },
+      {
+        "id": 5689697795833856
+      },
+      {
+        "id": 5910974510923776
+      },
+      {
+        "id": 5757468554559488
+      },
+      {
+        "id": 4644337115725824
+      }
+    ],
+    "webkit": [
+      {
+        "id": "feature-download-attribute"
+      },
+      {
+        "id": "feature-picture-element"
+      },
+      {
+        "id": "specification-preload"
+      },
+      {
+        "id": "feature-srcset-w-descriptor-and-related-sizes-attribute"
+      }
+    ]
   }
 }

--- a/data/idle-detection.json
+++ b/data/idle-detection.json
@@ -1,5 +1,10 @@
 {
   "statusref": {
-    "chrome": 4590256452009984
+    "chrome": [
+      {
+        "id": 4590256452009984,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/image-capture.json
+++ b/data/image-capture.json
@@ -1,5 +1,10 @@
 {
   "statusref": {
-    "chrome": 4843864737185792
+    "chrome": [
+      {
+        "id": 4843864737185792,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/input-device-capabilities.json
+++ b/data/input-device-capabilities.json
@@ -1,5 +1,10 @@
 {
   "statusref": {
-    "chrome": 5681847971348480
+    "chrome": [
+      {
+        "id": 5681847971348480,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/intersection-observer.json
+++ b/data/intersection-observer.json
@@ -1,10 +1,29 @@
 {
   "statusref": {
-    "bcd": "api.IntersectionObserver",
-    "caniuse": "intersectionobserver",
-    "chrome": 5695342691483648,
-    "edge": "Intersection Observer",
-    "webkit": "specification-intersection-observer"
+    "bcd": [
+      {
+        "id": "api.IntersectionObserver",
+        "representative": true
+      }
+    ],
+    "caniuse": [
+      {
+        "id": "intersectionobserver",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5695342691483648,
+        "representative": true
+      }
+    ],
+    "webkit": [
+      {
+        "id": "specification-intersection-observer",
+        "representative": true
+      }
+    ]
   },
   "polyfills": [
     {

--- a/data/is-input-pending.json
+++ b/data/is-input-pending.json
@@ -1,5 +1,10 @@
 {
   "statusref": {
-    "chrome": 5719830432841728
+    "chrome": [
+      {
+        "id": 5719830432841728,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/layout-instability.json
+++ b/data/layout-instability.json
@@ -1,5 +1,10 @@
 {
   "statusref": {
-    "chrome": 5110682739539968
+    "chrome": [
+      {
+        "id": 5110682739539968,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/longtasks.json
+++ b/data/longtasks.json
@@ -1,6 +1,16 @@
 {
   "statusref": {
-    "bcd": "api.PerformanceLongTaskTiming",
-    "chrome": 5738471184400384
+    "bcd": [
+      {
+        "id": "api.PerformanceLongTaskTiming",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5738471184400384,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/magnetometer.json
+++ b/data/magnetometer.json
@@ -1,6 +1,16 @@
 {
   "statusref": {
-    "caniuse": "magnetometer",
-    "chrome": 5698781827825664
+    "caniuse": [
+      {
+        "id": "magnetometer",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5698781827825664,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/media-capabilities.json
+++ b/data/media-capabilities.json
@@ -4,15 +4,35 @@
       "url": "https://w3c.github.io/media-capabilities/#decoding-encoding-capabilities",
       "title": "Encoding capabilities",
       "statusref": {
-        "chrome": 5123719190020096
+        "chrome": [
+          {
+            "id": 5123719190020096,
+            "representative": true
+          }
+        ]
       }
     },
     "decoding": {
       "url": "https://w3c.github.io/media-capabilities/#decoding-encoding-capabilities",
       "title": "Decoding capabilities",
       "statusref": {
-        "chrome": 5869632707624960
+        "chrome": [
+          {
+            "id": 5869632707624960,
+            "representative": true
+          }
+        ]
       }
     }
+  },
+  "statusref": {
+    "chrome": [
+      {
+        "id": 5123719190020096
+      },
+      {
+        "id": 5869632707624960
+      }
+    ]
   }
 }

--- a/data/media-source.json
+++ b/data/media-source.json
@@ -3,8 +3,20 @@
     "codec-switching": {
       "title": "Codec switching",
       "statusref": {
-        "chrome": 5719220952236032
+        "chrome": [
+          {
+            "id": 5719220952236032,
+            "representative": true
+          }
+        ]
       }
     }
+  },
+  "statusref": {
+    "chrome": [
+      {
+        "id": 5719220952236032
+      }
+    ]
   }
 }

--- a/data/mediacapture-fromelement.json
+++ b/data/mediacapture-fromelement.json
@@ -1,7 +1,16 @@
 {
   "statusref": {
-    "caniuse": "mediacapture-fromelement",
-    "chrome": 5522768674160640,
-    "edge": "Media Capture from HTML Media Element"
+    "caniuse": [
+      {
+        "id": "mediacapture-fromelement",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5522768674160640,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/mediacapture-streams.json
+++ b/data/mediacapture-streams.json
@@ -1,16 +1,48 @@
 {
   "statusref": {
-    "caniuse": "stream",
-    "chrome": 5755699816562688,
-    "edge": "Media Capture and Streams",
-    "webkit": "specification-media-capture-and-streams"
+    "caniuse": [
+      {
+        "id": "stream",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5755699816562688,
+        "representative": true
+      },
+      {
+        "id": 5145556682801152
+      }
+    ],
+    "webkit": [
+      {
+        "id": "specification-media-capture-and-streams",
+        "representative": true
+      }
+    ],
+    "bcd": [
+      {
+        "id": "api.MediaStreamTrack.getCapabilities"
+      }
+    ]
   },
   "features": {
     "capabilities": {
       "title": "Source capabilities",
       "statusref": {
-        "bcd": "api.MediaStreamTrack.getCapabilities",
-        "chrome": 5145556682801152
+        "bcd": [
+          {
+            "id": "api.MediaStreamTrack.getCapabilities",
+            "representative": true
+          }
+        ],
+        "chrome": [
+          {
+            "id": 5145556682801152,
+            "representative": true
+          }
+        ]
       }
     }
   }

--- a/data/mediaqueries.json
+++ b/data/mediaqueries.json
@@ -1,15 +1,39 @@
 {
   "statusref": {
-    "webkit": "specification-css-media-queries-level-4"
+    "webkit": [
+      {
+        "id": "specification-css-media-queries-level-4",
+        "representative": true
+      }
+    ],
+    "caniuse": [
+      {
+        "id": "css-media-interaction"
+      }
+    ],
+    "chrome": [
+      {
+        "id": 6460705494532096
+      }
+    ]
   },
   "features": {
     "mf-interaction": {
       "url": "https://drafts.csswg.org/mediaqueries-4/#mf-interaction",
       "title": "Interaction media features",
       "statusref": {
-        "caniuse": "css-media-interaction",
-        "chrome": 6460705494532096,
-        "edge": "Media Queries Level 4: pointer and hover"
+        "caniuse": [
+          {
+            "id": "css-media-interaction",
+            "representative": true
+          }
+        ],
+        "chrome": [
+          {
+            "id": 6460705494532096,
+            "representative": true
+          }
+        ]
       }
     }
   }

--- a/data/mediasession.json
+++ b/data/mediasession.json
@@ -1,7 +1,16 @@
 {
   "statusref": {
-    "bcd": "api.MediaSession",
-    "chrome": 5639924124483584,
-    "edge": "Media Session"
+    "bcd": [
+      {
+        "id": "api.MediaSession",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5639924124483584,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/mediastream-recording.json
+++ b/data/mediastream-recording.json
@@ -1,8 +1,22 @@
 {
   "statusref": {
-    "bcd": "api.MediaRecorder",
-    "caniuse": "mediarecorder",
-    "chrome": 5929649028726784,
-    "edge": "MediaRecorder"
+    "bcd": [
+      {
+        "id": "api.MediaRecorder",
+        "representative": true
+      }
+    ],
+    "caniuse": [
+      {
+        "id": "mediarecorder",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5929649028726784,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/mixed-content.json
+++ b/data/mixed-content.json
@@ -1,6 +1,16 @@
 {
   "statusref": {
-    "chrome": 6263395770695680,
-    "webkit": "feature-strict-mixed-content-checking"
+    "chrome": [
+      {
+        "id": 6263395770695680,
+        "representative": true
+      }
+    ],
+    "webkit": [
+      {
+        "id": "feature-strict-mixed-content-checking",
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/mst-content-hint.json
+++ b/data/mst-content-hint.json
@@ -1,5 +1,10 @@
 {
   "statusref": {
-    "chrome": 5689466211532800
+    "chrome": [
+      {
+        "id": 5689466211532800,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/navigation-timing.json
+++ b/data/navigation-timing.json
@@ -1,8 +1,22 @@
 {
   "statusref": {
-    "caniuse": "nav-timing",
-    "chrome": 5584144679567360,
-    "edge": "Navigation Timing API",
-    "webkit": "specification-navigation-timing-level-1"
+    "caniuse": [
+      {
+        "id": "nav-timing",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5584144679567360,
+        "representative": true
+      }
+    ],
+    "webkit": [
+      {
+        "id": "specification-navigation-timing-level-1",
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/netinfo.json
+++ b/data/netinfo.json
@@ -1,6 +1,16 @@
 {
   "statusref": {
-    "caniuse": "netinfo",
-    "chrome": 6338383617982464
+    "caniuse": [
+      {
+        "id": "netinfo",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 6338383617982464,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/notifications.json
+++ b/data/notifications.json
@@ -1,7 +1,16 @@
 {
   "statusref": {
-    "caniuse": "notifications",
-    "chrome": 5064350557536256,
-    "edge": "Web Notifications"
+    "caniuse": [
+      {
+        "id": "notifications",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5064350557536256,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/orientation-event.json
+++ b/data/orientation-event.json
@@ -1,8 +1,22 @@
 {
   "statusref": {
-    "caniuse": "deviceorientation",
-    "chrome": 5874690627207168,
-    "edge": "Device Orientation",
-    "webkit": "specification-deviceorientation-events"
+    "caniuse": [
+      {
+        "id": "deviceorientation",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5874690627207168,
+        "representative": true
+      }
+    ],
+    "webkit": [
+      {
+        "id": "specification-deviceorientation-events",
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/orientation-sensor.json
+++ b/data/orientation-sensor.json
@@ -1,7 +1,17 @@
 {
   "statusref": {
-    "caniuse": "orientation-sensor",
-    "chrome": 5698781827825664
+    "caniuse": [
+      {
+        "id": "orientation-sensor",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5698781827825664,
+        "representative": true
+      }
+    ]
   },
   "polyfills": [
     {

--- a/data/page-lifecycle.json
+++ b/data/page-lifecycle.json
@@ -1,5 +1,10 @@
 {
   "statusref": {
-    "chrome": 5644602711212032
+    "chrome": [
+      {
+        "id": 5644602711212032,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/paint-timing.json
+++ b/data/paint-timing.json
@@ -1,6 +1,16 @@
 {
   "statusref": {
-    "bcd": "api.PerformancePaintTiming",
-    "chrome": 5688621814251520
+    "bcd": [
+      {
+        "id": "api.PerformancePaintTiming",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5688621814251520,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/payment-handler.json
+++ b/data/payment-handler.json
@@ -1,6 +1,16 @@
 {
   "statusref": {
-    "bcd": "api.PaymentManager",
-    "chrome": 5160285237149696
+    "bcd": [
+      {
+        "id": "api.PaymentManager",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5160285237149696,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/payment-method-basic-card.json
+++ b/data/payment-method-basic-card.json
@@ -1,6 +1,16 @@
 {
   "statusref": {
-    "bcd": "api.BasicCardRequest",
-    "chrome": 5408502604365824
+    "bcd": [
+      {
+        "id": "api.BasicCardRequest",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5408502604365824,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/payment-method-manifest.json
+++ b/data/payment-method-manifest.json
@@ -1,5 +1,10 @@
 {
   "statusref": {
-    "chrome": 5716168929181696
+    "chrome": [
+      {
+        "id": 5716168929181696,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/payment-request.json
+++ b/data/payment-request.json
@@ -1,8 +1,22 @@
 {
   "statusref": {
-    "caniuse": "payment-request",
-    "chrome": 5639348045217792,
-    "edge": "Payment Request API",
-    "webkit": "specification-payment-request"
+    "caniuse": [
+      {
+        "id": "payment-request",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5639348045217792,
+        "representative": true
+      }
+    ],
+    "webkit": [
+      {
+        "id": "specification-payment-request",
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/performance-measure-memory.json
+++ b/data/performance-measure-memory.json
@@ -1,5 +1,10 @@
 {
   "statusref": {
-    "chrome": 5685965186138112
+    "chrome": [
+      {
+        "id": 5685965186138112,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/performance-timeline.json
+++ b/data/performance-timeline.json
@@ -4,14 +4,34 @@
       "url": "https://w3c.github.io/performance-timeline/#the-performanceobserver-interface",
       "title": "PerformanceObserver interface",
       "statusref": {
-        "chrome": 5945504202489856
+        "chrome": [
+          {
+            "id": 5945504202489856,
+            "representative": true
+          }
+        ]
       }
     },
     "worker": {
       "title": "Available in Workers",
       "statusref": {
-        "chrome": 6337483654561792
+        "chrome": [
+          {
+            "id": 6337483654561792,
+            "representative": true
+          }
+        ]
       }
     }
+  },
+  "statusref": {
+    "chrome": [
+      {
+        "id": 5945504202489856
+      },
+      {
+        "id": 6337483654561792
+      }
+    ]
   }
 }

--- a/data/permissions-policy.json
+++ b/data/permissions-policy.json
@@ -1,6 +1,16 @@
 {
   "statusref": {
-    "caniuse": "permissions-policy",
-    "chrome": 5745992911552512
+    "caniuse": [
+      {
+        "id": "permissions-policy",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5745992911552512,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/permissions-request.json
+++ b/data/permissions-request.json
@@ -1,5 +1,10 @@
 {
   "statusref": {
-    "chrome": 5707368532803584
+    "chrome": [
+      {
+        "id": 5707368532803584,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/permissions-revoke.json
+++ b/data/permissions-revoke.json
@@ -1,5 +1,10 @@
 {
   "statusref": {
-    "chrome": 5707368532803584
+    "chrome": [
+      {
+        "id": 5707368532803584,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/permissions.json
+++ b/data/permissions.json
@@ -1,6 +1,16 @@
 {
   "statusref": {
-    "caniuse": "permissions-api",
-    "chrome": 6376494003650560
+    "caniuse": [
+      {
+        "id": "permissions-api",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 6376494003650560,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/picture-in-picture.json
+++ b/data/picture-in-picture.json
@@ -1,9 +1,23 @@
 {
   "statusref": {
-    "bcd": "api.PictureInPicture",
-    "caniuse": "picture-in-picture",
-    "chrome": 5729206566649856,
-    "edge": "Picture-in-Picture",
+    "bcd": [
+      {
+        "id": "api.PictureInPicture",
+        "representative": true
+      }
+    ],
+    "caniuse": [
+      {
+        "id": "picture-in-picture",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5729206566649856,
+        "representative": true
+      }
+    ],
     "manual": [
       {
         "ua": "safari",

--- a/data/pointerevents.json
+++ b/data/pointerevents.json
@@ -1,8 +1,22 @@
 {
   "statusref": {
-    "bcd": "css.properties.touch-action",
-    "caniuse": "css-touch-action",
-    "chrome": 5912074022551552,
-    "edge": "CSS touch-action"
+    "bcd": [
+      {
+        "id": "css.properties.touch-action",
+        "representative": true
+      }
+    ],
+    "caniuse": [
+      {
+        "id": "css-touch-action",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5912074022551552,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/pointerlock.json
+++ b/data/pointerlock.json
@@ -1,8 +1,22 @@
 {
   "statusref": {
-    "caniuse": "pointerlock",
-    "chrome": 6753200417800192,
-    "edge": "Pointer Lock (Mouse Lock)",
-    "webkit": "specification-pointer-lock"
+    "caniuse": [
+      {
+        "id": "pointerlock",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 6753200417800192,
+        "representative": true
+      }
+    ],
+    "webkit": [
+      {
+        "id": "specification-pointer-lock",
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/portals.json
+++ b/data/portals.json
@@ -1,5 +1,10 @@
 {
   "statusref": {
-    "chrome": 4828882419056640
+    "chrome": [
+      {
+        "id": 4828882419056640,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/presentation-api.json
+++ b/data/presentation-api.json
@@ -1,6 +1,11 @@
 {
   "statusref": {
-    "chrome": 6676265876586496,
+    "chrome": [
+      {
+        "id": 6676265876586496,
+        "representative": true
+      }
+    ],
     "manual": [
       {
         "ua": "webkit",

--- a/data/priority-hints.json
+++ b/data/priority-hints.json
@@ -1,5 +1,10 @@
 {
   "statusref": {
-    "chrome": 5273474901737472
+    "chrome": [
+      {
+        "id": 5273474901737472,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/proximity.json
+++ b/data/proximity.json
@@ -1,6 +1,11 @@
 {
   "statusref": {
-    "caniuse": "proximity",
+    "caniuse": [
+      {
+        "id": "proximity",
+        "representative": true
+      }
+    ],
     "manual": [
       {
         "ua": "firefox",

--- a/data/push-api.json
+++ b/data/push-api.json
@@ -1,7 +1,16 @@
 {
   "statusref": {
-    "caniuse": "push-api",
-    "chrome": 5416033485586432,
-    "edge": "Push API"
+    "caniuse": [
+      {
+        "id": "push-api",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5416033485586432,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/referrer-policy.json
+++ b/data/referrer-policy.json
@@ -1,6 +1,16 @@
 {
   "statusref": {
-    "caniuse": "referrer-policy",
-    "chrome": 5639972996513792
+    "caniuse": [
+      {
+        "id": "referrer-policy",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5639972996513792,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/remote-playback.json
+++ b/data/remote-playback.json
@@ -1,5 +1,10 @@
 {
   "statusref": {
-    "chrome": 5778318691401728
+    "chrome": [
+      {
+        "id": 5778318691401728,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/requestidlecallback.json
+++ b/data/requestidlecallback.json
@@ -1,9 +1,28 @@
 {
   "statusref": {
-    "bcd": "api.Window.requestIdleCallback",
-    "caniuse": "requestidlecallback",
-    "chrome": 5572795866021888,
-    "edge": "requestIdleCallback",
-    "webkit": "feature-requestidlecallback"
+    "bcd": [
+      {
+        "id": "api.Window.requestIdleCallback",
+        "representative": true
+      }
+    ],
+    "caniuse": [
+      {
+        "id": "requestidlecallback",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5572795866021888,
+        "representative": true
+      }
+    ],
+    "webkit": [
+      {
+        "id": "feature-requestidlecallback",
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/resize-observer.json
+++ b/data/resize-observer.json
@@ -1,6 +1,16 @@
 {
   "statusref": {
-    "caniuse": "resizeobserver",
-    "chrome": 5705346022637568
+    "caniuse": [
+      {
+        "id": "resizeobserver",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5705346022637568,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/resource-hints.json
+++ b/data/resource-hints.json
@@ -4,35 +4,85 @@
       "url": "https://w3c.github.io/resource-hints/#dns-prefetch",
       "title": "DNS prefetch",
       "statusref": {
-        "caniuse": "link-rel-dns-prefetch",
-        "edge": "DNS Prefetch Resource Hints"
+        "caniuse": [
+          {
+            "id": "link-rel-dns-prefetch",
+            "representative": true
+          }
+        ]
       }
     },
     "preconnect": {
       "url": "https://w3c.github.io/resource-hints/#preconnect",
       "title": "Preconnect",
       "statusref": {
-        "caniuse": "link-rel-preconnect",
-        "chrome": 5560623895150592,
-        "edge": "Preconnect Resource Hints"
+        "caniuse": [
+          {
+            "id": "link-rel-preconnect",
+            "representative": true
+          }
+        ],
+        "chrome": [
+          {
+            "id": 5560623895150592,
+            "representative": true
+          }
+        ]
       }
     },
     "prefetch": {
       "url": "https://w3c.github.io/resource-hints/#prefetch",
       "title": "Prefetch",
       "statusref": {
-        "caniuse": "link-rel-prefetch",
-        "chrome": 5383221353119744,
-        "edge": "Prefetch Resource Hints"
+        "caniuse": [
+          {
+            "id": "link-rel-prefetch",
+            "representative": true
+          }
+        ],
+        "chrome": [
+          {
+            "id": 5383221353119744,
+            "representative": true
+          }
+        ]
       }
     },
     "prerender": {
       "url": "https://w3c.github.io/resource-hints/#prerender",
       "title": "Prerender",
       "statusref": {
-        "caniuse": "link-rel-prerender",
-        "edge": "Prerender Resource Hints"
+        "caniuse": [
+          {
+            "id": "link-rel-prerender",
+            "representative": true
+          }
+        ]
       }
     }
+  },
+  "statusref": {
+    "caniuse": [
+      {
+        "id": "link-rel-dns-prefetch"
+      },
+      {
+        "id": "link-rel-preconnect"
+      },
+      {
+        "id": "link-rel-prefetch"
+      },
+      {
+        "id": "link-rel-prerender"
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5560623895150592
+      },
+      {
+        "id": 5383221353119744
+      }
+    ]
   }
 }

--- a/data/resource-timing.json
+++ b/data/resource-timing.json
@@ -1,8 +1,22 @@
 {
   "statusref": {
-    "caniuse": "resource-timing",
-    "chrome": 5796350423728128,
-    "edge": "Resource Timing API",
-    "webkit": "specification-resource-timing-level-2"
+    "caniuse": [
+      {
+        "id": "resource-timing",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5796350423728128,
+        "representative": true
+      }
+    ],
+    "webkit": [
+      {
+        "id": "specification-resource-timing-level-2",
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/screen-capture.json
+++ b/data/screen-capture.json
@@ -1,6 +1,10 @@
 {
   "statusref": {
-    "chrome": 6744724455030784,
-    "edge": "Screen Capture"
+    "chrome": [
+      {
+        "id": 6744724455030784,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/screen-orientation.json
+++ b/data/screen-orientation.json
@@ -1,7 +1,16 @@
 {
   "statusref": {
-    "caniuse": "screen-orientation",
-    "chrome": 6191285283061760,
-    "edge": "Screen Orientation API"
+    "caniuse": [
+      {
+        "id": "screen-orientation",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 6191285283061760,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/secure-contexts.json
+++ b/data/secure-contexts.json
@@ -1,6 +1,10 @@
 {
   "statusref": {
-    "chrome": 6021277022158848,
-    "edge": "Secure Contexts"
+    "chrome": [
+      {
+        "id": 6021277022158848,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/server-timing.json
+++ b/data/server-timing.json
@@ -1,7 +1,16 @@
 {
   "statusref": {
-    "bcd": "api.PerformanceServerTiming",
-    "chrome": 5695708376072192,
-    "edge": "Server Timing"
+    "bcd": [
+      {
+        "id": "api.PerformanceServerTiming",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5695708376072192,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/service-workers.json
+++ b/data/service-workers.json
@@ -1,8 +1,22 @@
 {
   "statusref": {
-    "caniuse": "serviceworkers",
-    "chrome": 6561526227927040,
-    "edge": "Service Worker",
-    "webkit": "specification-service-workers"
+    "caniuse": [
+      {
+        "id": "serviceworkers",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 6561526227927040,
+        "representative": true
+      }
+    ],
+    "webkit": [
+      {
+        "id": "specification-service-workers",
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/speech-api.json
+++ b/data/speech-api.json
@@ -1,7 +1,16 @@
 {
   "statusref": {
-    "caniuse": "speech-recognition",
-    "chrome": 5908775487668224,
-    "edge": "Web Speech API (Speech Recognition)"
+    "caniuse": [
+      {
+        "id": "speech-recognition",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5908775487668224,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/storage-access.json
+++ b/data/storage-access.json
@@ -1,20 +1,43 @@
 {
   "statusref": {
-    "chrome": 5612590694662144
+    "chrome": [
+      {
+        "id": 5612590694662144,
+        "representative": true
+      }
+    ],
+    "bcd": [
+      {
+        "id": "api.Document.hasStorageAccess"
+      },
+      {
+        "id": "api.Document.requestStorageAccess"
+      }
+    ]
   },
   "features": {
     "hasStorageAccess": {
       "url": "https://privacycg.github.io/storage-access/#dom-document-hasstorageaccess",
       "title": "hasStorageAccess method",
       "statusref": {
-        "bcd": "api.Document.hasStorageAccess"
+        "bcd": [
+          {
+            "id": "api.Document.hasStorageAccess",
+            "representative": true
+          }
+        ]
       }
     },
     "requestStorageAccess": {
       "url": "https://privacycg.github.io/storage-access/#dom-document-requeststorageaccess",
       "title": "requestStorageAccess method",
       "statusref": {
-        "bcd": "api.Document.requestStorageAccess"
+        "bcd": [
+          {
+            "id": "api.Document.requestStorageAccess",
+            "representative": true
+          }
+        ]
       }
     }
   }

--- a/data/storage.json
+++ b/data/storage.json
@@ -1,22 +1,61 @@
 {
   "statusref": {
-    "bcd": "api.StorageManager"
+    "bcd": [
+      {
+        "id": "api.StorageManager",
+        "representative": true
+      },
+      {
+        "id": "api.StorageManager.estimate"
+      },
+      {
+        "id": "api.StorageManager.permission"
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5630353511284736
+      },
+      {
+        "id": 4931497563783168
+      }
+    ]
   },
   "features": {
     "estimate": {
       "url": "https://storage.spec.whatwg.org/#dom-storagemanager-estimate",
       "title": "estimate() API",
       "statusref": {
-        "bcd": "api.StorageManager.estimate",
-        "chrome": 5630353511284736
+        "bcd": [
+          {
+            "id": "api.StorageManager.estimate",
+            "representative": true
+          }
+        ],
+        "chrome": [
+          {
+            "id": 5630353511284736,
+            "representative": true
+          }
+        ]
       }
     },
     "persist": {
       "url": "https://storage.spec.whatwg.org/#dom-storagemanager-persist",
       "title": "Persistent storage permission",
       "statusref": {
-        "bcd": "api.StorageManager.permission",
-        "chrome": 4931497563783168
+        "bcd": [
+          {
+            "id": "api.StorageManager.permission",
+            "representative": true
+          }
+        ],
+        "chrome": [
+          {
+            "id": 4931497563783168,
+            "representative": true
+          }
+        ]
       }
     }
   }

--- a/data/streams.json
+++ b/data/streams.json
@@ -1,32 +1,77 @@
 {
   "statusref": {
-    "caniuse": "streams",
-    "chrome": 6605041225957376,
-    "webkit": "specification-streams"
+    "caniuse": [
+      {
+        "id": "streams",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 6605041225957376,
+        "representative": true
+      },
+      {
+        "id": 4531143755956224
+      },
+      {
+        "id": 5928498656968704
+      },
+      {
+        "id": 5466425791610880
+      }
+    ],
+    "webkit": [
+      {
+        "id": "specification-streams",
+        "representative": true
+      },
+      {
+        "id": "feature-readable-streams"
+      }
+    ]
   },
   "features": {
     "ReadableStream": {
       "url": "https://streams.spec.whatwg.org/#rs",
       "title": "ReadableStream interface",
       "statusref": {
-        "chrome": 4531143755956224,
-        "edge": "Streams API: ReadableStream",
-        "webkit": "feature-readable-streams"
+        "chrome": [
+          {
+            "id": 4531143755956224,
+            "representative": true
+          }
+        ],
+        "webkit": [
+          {
+            "id": "feature-readable-streams",
+            "representative": true
+          }
+        ]
       }
     },
     "WritableStream": {
       "url": "https://streams.spec.whatwg.org/#ws",
       "title": "WritableStream interface",
       "statusref": {
-        "chrome": 5928498656968704,
-        "edge": "Streams API: WritableStream"
+        "chrome": [
+          {
+            "id": 5928498656968704,
+            "representative": true
+          }
+        ]
       }
     },
     "TransformStream": {
       "url": "https://streams.spec.whatwg.org/#ts",
       "title": "TransformStream interface",
       "statusref": {
-        "chrome": 5466425791610880
+        "chrome": [
+          {
+            "id": 5466425791610880,
+            "representative": true
+          }
+        ]
       }
     }
   }

--- a/data/touch-events.json
+++ b/data/touch-events.json
@@ -1,7 +1,16 @@
 {
   "statusref": {
-    "caniuse": "touch",
-    "chrome": 6156165603917824,
-    "edge": "Touch Events"
+    "caniuse": [
+      {
+        "id": "touch",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 6156165603917824,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/trusted-types.json
+++ b/data/trusted-types.json
@@ -1,7 +1,17 @@
 {
   "statusref": {
-    "caniuse": "trusted-types",
-    "chrome": 5650088592408576
+    "caniuse": [
+      {
+        "id": "trusted-types",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5650088592408576,
+        "representative": true
+      }
+    ]
   },
   "polyfills": [
     {

--- a/data/ua-client-hints.json
+++ b/data/ua-client-hints.json
@@ -1,5 +1,10 @@
 {
   "statusref": {
-    "chrome": 5995832180473856
+    "chrome": [
+      {
+        "id": 5995832180473856,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/upgrade-insecure-requests.json
+++ b/data/upgrade-insecure-requests.json
@@ -1,8 +1,22 @@
 {
   "statusref": {
-    "caniuse": "upgradeinsecurerequests",
-    "chrome": 6534575509471232,
-    "edge": "CSP upgrade-insecure-requests directive",
-    "webkit": "feature-upgrade-insecure-requests"
+    "caniuse": [
+      {
+        "id": "upgradeinsecurerequests",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 6534575509471232,
+        "representative": true
+      }
+    ],
+    "webkit": [
+      {
+        "id": "feature-upgrade-insecure-requests",
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/user-timing.json
+++ b/data/user-timing.json
@@ -1,8 +1,22 @@
 {
   "statusref": {
-    "caniuse": "user-timing",
-    "chrome": 5066549580791808,
-    "edge": "User Timing API",
-    "webkit": "specification-user-timing-level-2"
+    "caniuse": [
+      {
+        "id": "user-timing",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5066549580791808,
+        "representative": true
+      }
+    ],
+    "webkit": [
+      {
+        "id": "specification-user-timing-level-2",
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/vibration.json
+++ b/data/vibration.json
@@ -1,8 +1,22 @@
 {
   "statusref": {
-    "caniuse": "vibration",
-    "chrome": 5698768766763008,
-    "edge": "Vibration API",
-    "webkit": "specification-vibration-api"
+    "caniuse": [
+      {
+        "id": "vibration",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5698768766763008,
+        "representative": true
+      }
+    ],
+    "webkit": [
+      {
+        "id": "specification-vibration-api",
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/video-rvfc.json
+++ b/data/video-rvfc.json
@@ -1,5 +1,10 @@
 {
   "statusref": {
-    "chrome": 6335927192387584
+    "chrome": [
+      {
+        "id": 6335927192387584,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/visual-viewport.json
+++ b/data/visual-viewport.json
@@ -1,6 +1,16 @@
 {
   "statusref": {
-    "chrome": 5737866978131968,
-    "webkit": "specification-visual-viewport-api"
+    "chrome": [
+      {
+        "id": 5737866978131968,
+        "representative": true
+      }
+    ],
+    "webkit": [
+      {
+        "id": "specification-visual-viewport-api",
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/wai-aria.json
+++ b/data/wai-aria.json
@@ -1,7 +1,16 @@
 {
   "statusref": {
-    "caniuse": "wai-aria",
-    "chrome": 5761503818940416,
-    "edge": "Accessible Rich Internet Applications (WAI-ARIA) 1.1"
+    "caniuse": [
+      {
+        "id": "wai-aria",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5761503818940416,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/wasm-core.json
+++ b/data/wasm-core.json
@@ -1,7 +1,22 @@
 {
   "statusref": {
-    "bcd": "javascript.builtins.WebAssembly",
-    "caniuse": "wasm",
-    "chrome": 5453022515691520
+    "bcd": [
+      {
+        "id": "javascript.builtins.WebAssembly",
+        "representative": true
+      }
+    ],
+    "caniuse": [
+      {
+        "id": "wasm",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5453022515691520,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/web-animations.json
+++ b/data/web-animations.json
@@ -1,8 +1,22 @@
 {
   "statusref": {
-    "caniuse": "web-animation",
-    "chrome": 5650817352728576,
-    "edge": "Web Animations JavaScript API",
-    "webkit": "specification-web-animations"
+    "caniuse": [
+      {
+        "id": "web-animation",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5650817352728576,
+        "representative": true
+      }
+    ],
+    "webkit": [
+      {
+        "id": "specification-web-animations",
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/web-bluetooth.json
+++ b/data/web-bluetooth.json
@@ -1,8 +1,22 @@
 {
   "statusref": {
-    "caniuse": "web-bluetooth",
-    "chrome": 5264933985976320,
-    "edge": "Web Bluetooth",
-    "webkit": "specification-web-bluetooth"
+    "caniuse": [
+      {
+        "id": "web-bluetooth",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5264933985976320,
+        "representative": true
+      }
+    ],
+    "webkit": [
+      {
+        "id": "specification-web-bluetooth",
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/web-locks.json
+++ b/data/web-locks.json
@@ -1,6 +1,16 @@
 {
   "statusref": {
-    "bcd": "api.Navigator.locks",
-    "chrome": 5712361335816192
+    "bcd": [
+      {
+        "id": "api.Navigator.locks",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5712361335816192,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/web-nfc.json
+++ b/data/web-nfc.json
@@ -1,6 +1,10 @@
 {
   "statusref": {
-    "chrome": 6261030015467520,
-    "edge": "Web NFC API"
+    "chrome": [
+      {
+        "id": 6261030015467520,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/web-share-target.json
+++ b/data/web-share-target.json
@@ -1,5 +1,10 @@
 {
   "statusref": {
-    "chrome": 5662315307335680
+    "chrome": [
+      {
+        "id": 5662315307335680,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/web-share.json
+++ b/data/web-share.json
@@ -1,8 +1,22 @@
 {
   "statusref": {
-    "caniuse": "web-share",
-    "chrome": 5668769141620736,
-    "edge": "Web Share API",
-    "webkit": "specification-web-share"
+    "caniuse": [
+      {
+        "id": "web-share",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5668769141620736,
+        "representative": true
+      }
+    ],
+    "webkit": [
+      {
+        "id": "specification-web-share",
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/webaudio.json
+++ b/data/webaudio.json
@@ -1,17 +1,49 @@
 {
   "statusref": {
-    "caniuse": "audio-api",
-    "chrome": 6261718720184320,
-    "edge": "Web Audio API",
-    "webkit": "specification-web-audio"
+    "caniuse": [
+      {
+        "id": "audio-api",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 6261718720184320,
+        "representative": true
+      },
+      {
+        "id": 4588498229133312
+      }
+    ],
+    "webkit": [
+      {
+        "id": "specification-web-audio",
+        "representative": true
+      }
+    ],
+    "bcd": [
+      {
+        "id": "api.AudioWorklet"
+      }
+    ]
   },
   "features": {
     "worklet": {
       "url": "https://webaudio.github.io/web-audio-api/#audioworklet",
       "title": "The AudioWorklet interface",
       "statusref": {
-        "bcd": "api.AudioWorklet",
-        "chrome": 4588498229133312
+        "bcd": [
+          {
+            "id": "api.AudioWorklet",
+            "representative": true
+          }
+        ],
+        "chrome": [
+          {
+            "id": 4588498229133312,
+            "representative": true
+          }
+        ]
       }
     }
   }

--- a/data/webauthn.json
+++ b/data/webauthn.json
@@ -1,8 +1,22 @@
 {
   "statusref": {
-    "caniuse": "webauthn",
-    "chrome": 5669923372138496,
-    "edge": "Web Authentication API",
-    "webkit": "specification-web-authentication"
+    "caniuse": [
+      {
+        "id": "webauthn",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5669923372138496,
+        "representative": true
+      }
+    ],
+    "webkit": [
+      {
+        "id": "specification-web-authentication",
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/webcodecs.json
+++ b/data/webcodecs.json
@@ -1,5 +1,10 @@
 {
   "statusref": {
-    "chrome": 5669293909868544
+    "chrome": [
+      {
+        "id": 5669293909868544,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/webgl1.json
+++ b/data/webgl1.json
@@ -1,9 +1,28 @@
 {
   "statusref": {
-    "bcd": "api.HTMLCanvasElement.webgl_context",
-    "caniuse": "webgl",
-    "chrome": 6049512976023552,
-    "edge": "WebGL  (Canvas 3D)",
-    "webkit": "specification-webgl-1"
+    "bcd": [
+      {
+        "id": "api.HTMLCanvasElement.webgl_context",
+        "representative": true
+      }
+    ],
+    "caniuse": [
+      {
+        "id": "webgl",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 6049512976023552,
+        "representative": true
+      }
+    ],
+    "webkit": [
+      {
+        "id": "specification-webgl-1",
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/webgpu.json
+++ b/data/webgpu.json
@@ -1,6 +1,16 @@
 {
   "statusref": {
-    "caniuse": "webgpu",
-    "chrome": 6213121689518080
+    "caniuse": [
+      {
+        "id": "webgpu",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 6213121689518080,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/webhid.json
+++ b/data/webhid.json
@@ -1,5 +1,10 @@
 {
   "statusref": {
-    "chrome": 5172464636133376
+    "chrome": [
+      {
+        "id": 5172464636133376,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/webrtc-stats.json
+++ b/data/webrtc-stats.json
@@ -1,5 +1,10 @@
 {
   "statusref": {
-    "chrome": 5665052275245056
+    "chrome": [
+      {
+        "id": 5665052275245056,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/webrtc-svc.json
+++ b/data/webrtc-svc.json
@@ -1,5 +1,10 @@
 {
   "statusref": {
-    "chrome": 5769626174619648
+    "chrome": [
+      {
+        "id": 5769626174619648,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/webrtc.json
+++ b/data/webrtc.json
@@ -1,17 +1,29 @@
 {
   "statusref": {
-    "caniuse": "rtcpeerconnection",
-    "chrome": 6612462929444864,
-    "edge": "WebRTC – WebRTC v1.0 API",
-    "webkit": "specification-webrtc"
+    "caniuse": [
+      {
+        "id": "rtcpeerconnection",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 6612462929444864,
+        "representative": true
+      }
+    ],
+    "webkit": [
+      {
+        "id": "specification-webrtc",
+        "representative": true
+      }
+    ]
   },
   "features": {
     "rtcdatachannel": {
       "url": "https://w3c.github.io/webrtc-pc/#peer-to-peer-data-api",
       "title": "RTC data channels",
-      "statusref": {
-        "edge": "RTC Data Channels"
-      }
+      "statusref": {}
     }
   }
 }

--- a/data/webusb.json
+++ b/data/webusb.json
@@ -1,7 +1,22 @@
 {
   "statusref": {
-    "caniuse": "webusb",
-    "chrome": 5651917954875392,
-    "webkit": "specification-webusb"
+    "caniuse": [
+      {
+        "id": "webusb",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5651917954875392,
+        "representative": true
+      }
+    ],
+    "webkit": [
+      {
+        "id": "specification-webusb",
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/webvtt.json
+++ b/data/webvtt.json
@@ -1,5 +1,10 @@
 {
   "statusref": {
-    "caniuse": "webvtt"
+    "caniuse": [
+      {
+        "id": "webvtt",
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/webxr-gamepads-module.json
+++ b/data/webxr-gamepads-module.json
@@ -1,5 +1,10 @@
 {
   "statusref": {
-    "chrome": 5659025263820800
+    "chrome": [
+      {
+        "id": 5659025263820800,
+        "representative": true
+      }
+    ]
   }
 }

--- a/data/webxr.json
+++ b/data/webxr.json
@@ -1,8 +1,23 @@
 {
   "statusref": {
-    "bcd": "api.XR",
-    "caniuse": "webxr",
-    "chrome": 5680169905815552
+    "bcd": [
+      {
+        "id": "api.XR",
+        "representative": true
+      }
+    ],
+    "caniuse": [
+      {
+        "id": "webxr",
+        "representative": true
+      }
+    ],
+    "chrome": [
+      {
+        "id": 5680169905815552,
+        "representative": true
+      }
+    ]
   },
   "polyfills": [
     {

--- a/data/xhr.json
+++ b/data/xhr.json
@@ -1,5 +1,10 @@
 {
   "statusref": {
-    "caniuse": "xhr2"
+    "caniuse": [
+      {
+        "id": "xhr2",
+        "representative": true
+      }
+    ]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,17 @@
 {
   "name": "browser-statuses",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "browser-statuses",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "license": "CC-BY-4.0",
       "devDependencies": {
         "@mdn/browser-compat-data": "4.2.1",
+        "@octokit/plugin-throttling": "^3.6.2",
+        "@octokit/rest": "^18.12.0",
         "abort-controller": "3.0.0",
         "ajv": "8.11.0",
         "ajv-formats": "2.1.1",
@@ -25,6 +27,151 @@
       "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-4.2.1.tgz",
       "integrity": "sha512-EWUguj2kd7ldmrF9F+vI5hUOralPd+sdsUnYbRy33vZTuZkduC1shE9TtEMEjAQwyfyMb4ole5KtjF8MsnQOlA==",
       "dev": true
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.5.0.tgz",
+      "integrity": "sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/types": "^6.0.3"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.6.0.tgz",
+      "integrity": "sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/auth-token": "^2.4.4",
+        "@octokit/graphql": "^4.5.8",
+        "@octokit/request": "^5.6.3",
+        "@octokit/request-error": "^2.0.5",
+        "@octokit/types": "^6.0.3",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.12.tgz",
+      "integrity": "sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/types": "^6.0.3",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.8.0.tgz",
+      "integrity": "sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/request": "^5.6.0",
+        "@octokit/types": "^6.0.3",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-11.2.0.tgz",
+      "integrity": "sha512-PBsVO+15KSlGmiI8QAzaqvsNlZlrDlyAJYcrXBCvVUxCp7VnXjkwPoFHgjEJXx3WF9BAwkA6nfCUA7i9sODzKA==",
+      "dev": true
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.17.0.tgz",
+      "integrity": "sha512-tzMbrbnam2Mt4AhuyCHvpRkS0oZ5MvwwcQPYGtMv4tUa5kkzG58SVB0fcsLulOZQeRnOgdkZWkRUiyBlh0Bkyw==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/types": "^6.34.0"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=2"
+      }
+    },
+    "node_modules/@octokit/plugin-request-log": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
+      "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
+      "dev": true,
+      "peerDependencies": {
+        "@octokit/core": ">=3"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.13.0.tgz",
+      "integrity": "sha512-uJjMTkN1KaOIgNtUPMtIXDOjx6dGYysdIFhgA52x4xSadQCz3b/zJexvITDVpANnfKPW/+E0xkOvLntqMYpviA==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/types": "^6.34.0",
+        "deprecation": "^2.3.1"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=3"
+      }
+    },
+    "node_modules/@octokit/plugin-throttling": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-3.6.2.tgz",
+      "integrity": "sha512-0az5fxgVlhFfFtiKLKVXTpmCG2tK3BG0fYI8SO4pmGlN1kyJktJVQA+6KKaFxtxMIWsuHmSEAkR6zSgtk86g2A==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/types": "^6.0.1",
+        "bottleneck": "^2.15.3"
+      },
+      "peerDependencies": {
+        "@octokit/core": "^3.5.0"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
+      "integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/endpoint": "^6.0.1",
+        "@octokit/request-error": "^2.1.0",
+        "@octokit/types": "^6.16.1",
+        "is-plain-object": "^5.0.0",
+        "node-fetch": "^2.6.7",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
+      "integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/types": "^6.0.3",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/@octokit/rest": {
+      "version": "18.12.0",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.12.0.tgz",
+      "integrity": "sha512-gDPiOHlyGavxr72y0guQEhLsemgVjwRePayJ+FcKc2SJqKUbxbkvf5kAZEWA/MKvsfYlQAMVzNJE3ezQcxMJ2Q==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/core": "^3.5.1",
+        "@octokit/plugin-paginate-rest": "^2.16.8",
+        "@octokit/plugin-request-log": "^1.0.4",
+        "@octokit/plugin-rest-endpoint-methods": "^5.12.0"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "6.34.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.34.0.tgz",
+      "integrity": "sha512-s1zLBjWhdEI2zwaoSgyOFoKSl109CUcVBCc7biPJ3aAf6LGLU6szDvi31JPU7bxfla2lqfhjbbg/5DdFNxOwHw==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/openapi-types": "^11.2.0"
+      }
     },
     "node_modules/@ungap/promise-all-settled": {
       "version": "1.1.2",
@@ -135,6 +282,12 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/before-after-hook": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
+      "integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ==",
+      "dev": true
+    },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -143,6 +296,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/bottleneck": {
+      "version": "2.19.5",
+      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+      "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
+      "dev": true
     },
     "node_modules/brace-expansion": {
       "version": "2.0.1",
@@ -307,6 +466,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
+      "dev": true
     },
     "node_modules/diff": {
       "version": "5.0.0",
@@ -577,6 +742,15 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-unicode-supported": {
@@ -993,6 +1167,12 @@
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
       "dev": true
     },
+    "node_modules/universal-user-agent": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+      "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
+      "dev": true
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -1124,6 +1304,140 @@
       "integrity": "sha512-EWUguj2kd7ldmrF9F+vI5hUOralPd+sdsUnYbRy33vZTuZkduC1shE9TtEMEjAQwyfyMb4ole5KtjF8MsnQOlA==",
       "dev": true
     },
+    "@octokit/auth-token": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.5.0.tgz",
+      "integrity": "sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^6.0.3"
+      }
+    },
+    "@octokit/core": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.6.0.tgz",
+      "integrity": "sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==",
+      "dev": true,
+      "requires": {
+        "@octokit/auth-token": "^2.4.4",
+        "@octokit/graphql": "^4.5.8",
+        "@octokit/request": "^5.6.3",
+        "@octokit/request-error": "^2.0.5",
+        "@octokit/types": "^6.0.3",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/endpoint": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.12.tgz",
+      "integrity": "sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^6.0.3",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/graphql": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.8.0.tgz",
+      "integrity": "sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==",
+      "dev": true,
+      "requires": {
+        "@octokit/request": "^5.6.0",
+        "@octokit/types": "^6.0.3",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/openapi-types": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-11.2.0.tgz",
+      "integrity": "sha512-PBsVO+15KSlGmiI8QAzaqvsNlZlrDlyAJYcrXBCvVUxCp7VnXjkwPoFHgjEJXx3WF9BAwkA6nfCUA7i9sODzKA==",
+      "dev": true
+    },
+    "@octokit/plugin-paginate-rest": {
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.17.0.tgz",
+      "integrity": "sha512-tzMbrbnam2Mt4AhuyCHvpRkS0oZ5MvwwcQPYGtMv4tUa5kkzG58SVB0fcsLulOZQeRnOgdkZWkRUiyBlh0Bkyw==",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^6.34.0"
+      }
+    },
+    "@octokit/plugin-request-log": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
+      "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
+      "dev": true,
+      "requires": {}
+    },
+    "@octokit/plugin-rest-endpoint-methods": {
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.13.0.tgz",
+      "integrity": "sha512-uJjMTkN1KaOIgNtUPMtIXDOjx6dGYysdIFhgA52x4xSadQCz3b/zJexvITDVpANnfKPW/+E0xkOvLntqMYpviA==",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^6.34.0",
+        "deprecation": "^2.3.1"
+      }
+    },
+    "@octokit/plugin-throttling": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-3.6.2.tgz",
+      "integrity": "sha512-0az5fxgVlhFfFtiKLKVXTpmCG2tK3BG0fYI8SO4pmGlN1kyJktJVQA+6KKaFxtxMIWsuHmSEAkR6zSgtk86g2A==",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^6.0.1",
+        "bottleneck": "^2.15.3"
+      }
+    },
+    "@octokit/request": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
+      "integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
+      "dev": true,
+      "requires": {
+        "@octokit/endpoint": "^6.0.1",
+        "@octokit/request-error": "^2.1.0",
+        "@octokit/types": "^6.16.1",
+        "is-plain-object": "^5.0.0",
+        "node-fetch": "^2.6.7",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/request-error": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
+      "integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^6.0.3",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      }
+    },
+    "@octokit/rest": {
+      "version": "18.12.0",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.12.0.tgz",
+      "integrity": "sha512-gDPiOHlyGavxr72y0guQEhLsemgVjwRePayJ+FcKc2SJqKUbxbkvf5kAZEWA/MKvsfYlQAMVzNJE3ezQcxMJ2Q==",
+      "dev": true,
+      "requires": {
+        "@octokit/core": "^3.5.1",
+        "@octokit/plugin-paginate-rest": "^2.16.8",
+        "@octokit/plugin-request-log": "^1.0.4",
+        "@octokit/plugin-rest-endpoint-methods": "^5.12.0"
+      }
+    },
+    "@octokit/types": {
+      "version": "6.34.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.34.0.tgz",
+      "integrity": "sha512-s1zLBjWhdEI2zwaoSgyOFoKSl109CUcVBCc7biPJ3aAf6LGLU6szDvi31JPU7bxfla2lqfhjbbg/5DdFNxOwHw==",
+      "dev": true,
+      "requires": {
+        "@octokit/openapi-types": "^11.2.0"
+      }
+    },
     "@ungap/promise-all-settled": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
@@ -1203,10 +1517,22 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "before-after-hook": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
+      "integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ==",
+      "dev": true
+    },
     "binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true
+    },
+    "bottleneck": {
+      "version": "2.19.5",
+      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+      "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
       "dev": true
     },
     "brace-expansion": {
@@ -1329,6 +1655,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
       "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "dev": true
+    },
+    "deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
       "dev": true
     },
     "diff": {
@@ -1529,6 +1861,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
       "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true
+    },
+    "is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
       "dev": true
     },
     "is-unicode-supported": {
@@ -1811,6 +2149,12 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+      "dev": true
+    },
+    "universal-user-agent": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+      "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
       "dev": true
     },
     "uri-js": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "browser-statuses",
   "description": "Implementation status for Web specifications based on info from external platform status sites",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/w3c/browser-statuses.git"
@@ -23,6 +23,8 @@
   },
   "devDependencies": {
     "@mdn/browser-compat-data": "4.2.1",
+    "@octokit/plugin-throttling": "^3.6.2",
+    "@octokit/rest": "^18.12.0",
     "abort-controller": "3.0.0",
     "ajv": "8.11.0",
     "ajv-formats": "2.1.1",

--- a/src/find-mappings.js
+++ b/src/find-mappings.js
@@ -1,0 +1,250 @@
+/*******************************************************************************
+Helper script to propose new mappings based on spec entries in browser-specs and
+implementation info from the implementation status data files.
+
+Run with:
+node src/find-mappings.js [--known]
+*******************************************************************************/
+
+import esMain from 'es-main';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import * as bcdParser from './parse-bcd.js';
+import * as caniuseParser from './parse-caniuse.js';
+import * as chromeParser from './parse-chrome.js';
+import * as webkitParser from './parse-webkit.js';
+
+// Compute __dirname (not exposed when ES6 modules are used)
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Import browser specs (cannot use "import" for now since entry point is JSON)
+const browserSpecs = JSON.parse(fs.readFileSync(
+  path.join(__dirname, '..', 'node_modules', 'web-specs', 'index.json'), 'utf8'));
+
+
+/**
+ * List of parsers
+ */
+const parsers = {
+  'bcd': bcdParser,
+  'caniuse': caniuseParser,
+  'chrome': chromeParser,
+  'webkit': webkitParser
+};
+
+
+async function fetchImplData() {
+  return Promise.all(Object.values(parsers).map(async parser => {
+    if (parser.fetchImplementationData) {
+      await parser.fetchImplementationData();
+    }
+  }));
+}
+
+function onlyUnique(value, index, self) {
+  return self.indexOf(value) === index;
+}
+
+function findMappingsForSpec(shortname, relatedSpecs, data) {
+  const res = JSON.parse(JSON.stringify(data ?? {}));
+  res.statusref = {};
+
+  console.log(`Finding mappings for ${shortname}`);
+
+  // Compute list of URLs that can be used to refer to the spec
+  relatedSpecs = relatedSpecs ?? [];
+  const relatedUrls = relatedSpecs
+    .map(spec => [
+      spec.url,
+      spec.nightly.url,
+      spec?.release?.url,
+      spec.series.nightlyUrl,
+      spec.series.releaseUrl
+    ])
+    .flat()
+    .filter(url => !!url)
+    .filter(onlyUnique);
+
+  // Find mappings and compute the new "statusref" property
+  const found = {};
+  for (const [name, parser] of Object.entries(parsers)) {
+    if (!parser.findMappings) {
+      continue;
+    }
+    const mappings = parser.findMappings(shortname, relatedUrls, data);
+    if (mappings && mappings.length > 0) {
+      found[name] = {};
+      for (const mapping of mappings) {
+        found[name][mapping.id] = mapping;
+      }
+
+      res.statusref[name] = mappings;
+    }
+
+    // Complete info with old info that we already had
+    const oldref = data?.statusref?.[name];
+    const newref = res.statusref[name] ?? [];
+    if (oldref) {
+      for (const oldmapping of oldref) {
+        const newmapping = newref.find(m => m.id === oldmapping.id);
+        if (newmapping) {
+          if (oldmapping.representative) {
+            newmapping.representative = oldmapping.representative;
+          }
+        }
+        else if (oldmapping.manual) {
+          newref.push(oldmapping);
+        }
+      }
+    }
+    if (newref.length > 0) {
+      res.statusref[name] = newref;
+    }
+
+    // Sort resulting array
+    if (res.statusref[name]) {
+      res.statusref[name].sort((m1, m2) => {
+        if (m1.id < m2.id) {
+          return -1;
+        }
+        if (m1.id > m2.id) {
+          return 1;
+        }
+        return 0;
+      });
+    }
+  }
+
+  // Analyze the new "statusref" property against the one we previously had
+  const analysis =  {
+    info: [],
+    changes: [],
+    todo: []
+  };
+
+  // Spec not yet in data?
+  if (!data) {
+    analysis.info.push(`Spec not yet in data folder`);
+  }
+
+  for (const name of Object.keys(parsers)) {
+    // No old mapping. No new mapping.
+    // Report and do nothing.
+    const oldref = data?.statusref?.[name];
+    const newref = (res.statusref[name] && res.statusref[name].length) ?
+      res.statusref[name] : null;
+    if (!oldref && !newref) {
+      analysis.info.push(`${name}: no mappings known/found`);
+    }
+
+    // No old mapping. New mappings found.
+    // Check which ones are "representative".
+    if (!oldref && newref) {
+      analysis.info.push(`${name}: new mappings found`);
+      for (const mapping of newref) {
+        analysis.changes.push(`Add ${name} mapping [${mapping.id}](${mapping.statusUrl})`);
+      }
+      analysis.todo.push(`Check "representative" flags for ${name} mappings`);
+    }
+
+    // Old mappings. No new mapping.
+    // Check old mappings and flag them as "manual"
+    if (oldref && !newref) {
+      analysis.info.push(`${name}: obsolete mappings found`);
+      for (const mapping of oldref) {
+        analysis.changes.push(`Drop old ${name} mapping ${mapping.id}`);
+        analysis.todo.push(`Check need to add "manual" flag to keep ${name} mapping ${mapping.id} if needed`)
+      }
+    }
+
+    // Old mappings. New mappings.
+    // For old mappings that don't exist in new mappings, check and add "manual".
+    // For new mappings that don't exist in old mappings, check "representative".
+    // For new mappings that update old mappings, check new info
+    // For new mappings that are the same as old mappings, report but do nothing.
+    if (oldref && newref) {
+      if ((oldref.length === newref.length) &&
+          oldref.every(mapping => newref.find(m => m.id === mapping.id))) {
+        analysis.info.push(`${name}: same mappings as before`);
+      }
+      else {
+        analysis.info.push(`${name}: other mappings found`);
+      }
+
+      for (const mapping of oldref) {
+        if (!newref.find(m => m.id === mapping.id)) {
+          analysis.changes.push(`Drop old ${name} mapping ${mapping.id}`);
+          analysis.todo.push(`Check need to add "manual" flag to keep ${name} mapping ${mapping.id} if needed`)
+        }
+      }
+
+      for (const mapping of newref) {
+        if (!oldref.find(m => m.id === mapping.id)) {
+          analysis.changes.push(`Add ${name} mapping [${mapping.id}](${mapping.statusUrl})`);
+        }
+        analysis.todo.push(`Check "representative" flags for ${name} mappings`);
+      }
+
+      for (const mapping of newref) {
+        const oldmapping = oldref.find(m => m.id === mapping.id);
+        if (!oldmapping) {
+          continue;
+        }
+        analysis.info.push(`Same ${name} mapping [${mapping.id}](${mapping.statusUrl}) as before`);
+      }
+    }
+  }
+  analysis.todo = analysis.todo.filter(onlyUnique);
+  analysis.changes.sort();
+  analysis.todo.sort();
+
+  return {
+    statusref: res.statusref,
+    analysis: analysis
+  };
+}
+
+export async function findMappings(dataFolder, onlyExistingOnes) {
+  await fetchImplData();
+
+  const files = fs.readdirSync(dataFolder)
+    .filter(f => f.endsWith('.json'))
+    .map(f => path.join(dataFolder, f));
+
+  // Group specs per series
+  const specSeries = {};
+  browserSpecs.map(spec => {
+    if (!specSeries[spec.series.shortname]) {
+      specSeries[spec.series.shortname] = [];
+    }
+    specSeries[spec.series.shortname].push(spec);
+  });
+
+  // Load known data
+  const data = {};
+  for (const file of files) {
+    const shortname = file.split(/\/|\\/).pop().split('.')[0];
+    data[shortname] = JSON.parse(fs.readFileSync(file, 'utf8'));
+  }
+
+  // Loop through spec series to find new/obsolete mappings
+  const results = {};
+  for (const [shortname, specs] of Object.entries(specSeries)) {
+    if (onlyExistingOnes && !data[shortname]) {
+      continue;
+    }
+    results[shortname] = findMappingsForSpec(shortname, specs, data[shortname]);
+  }
+
+  return results;
+}
+
+
+if (esMain(import.meta)) {
+  const onlyExistingOnes = !!process.argv.find(arg => arg === '--known');
+  const dataFolder = path.join(__dirname, '..', 'data');
+  findMappings(dataFolder, onlyExistingOnes)
+    .then(changes => fs.promises.writeFile("res.json", JSON.stringify(changes, null, 2)));
+}

--- a/src/parse-bcd.js
+++ b/src/parse-bcd.js
@@ -145,3 +145,43 @@ export function getImplementationStatus(key) {
   }
   return impl;
 }
+
+
+export function findMappings(shortname, relatedUrls, knownData) {
+  function findMatch(node, id) {
+    if (node.__compat && node.__compat.spec_url) {
+      const specUrls = [node.__compat.spec_url].flat();
+      if (!!relatedUrls.find(u => specUrls.find(specUrl => specUrl.startsWith(u)))) {
+        return [
+          {
+            id: id,
+            statusUrl: node.__compat.mdn_url,
+            specUrls: [node.__compat.spec_url].flat()
+          }
+        ];
+      }
+    }
+
+    if (typeof node === 'object' && node.constructor === Object) {
+      return Object.keys(node)
+        .filter(name => name !== '__compat')
+        .map(name => findMatch(node[name], id + (id ? '.' : '') + name))
+        .flat();
+    }
+    else {
+      return [];
+    }
+  }
+
+  const mappings = findMatch(bcd, '')
+    .map(feature => {
+      return {
+        id: feature.id,
+        name: feature.id,
+        statusUrl: feature.statusUrl,
+        specUrls: feature.specUrls
+      };
+    });
+
+  return mappings;
+}

--- a/src/parse-caniuse.js
+++ b/src/parse-caniuse.js
@@ -147,3 +147,22 @@ export function getImplementationStatus(key) {
   });
   return impl;
 }
+
+
+export function findMappings(shortname, relatedUrls, knownData) {
+  const mappings = Object.entries(data.data)
+    .filter(([id, feature]) => {
+      const url = feature.spec;
+      return id === shortname || (url && !!relatedUrls.find(u => url.startsWith(u)));
+    })
+    .map(([id, feature]) => {
+      return {
+        id: id,
+        name: feature.title,
+        statusUrl: `https://caniuse.com/${id}`,
+        specUrls: [feature.spec]
+      };
+    });
+
+  return mappings;
+}

--- a/src/parse-chrome.js
+++ b/src/parse-chrome.js
@@ -221,3 +221,23 @@ export function getImplementationStatus(key) {
 
   return impl;
 }
+
+
+export function findMappings(shortname, relatedUrls, knownData) {
+  const mappings = data
+    .filter(feature => {
+      const url = feature?.standards?.spec;
+      return url && !!relatedUrls.find(u => url.startsWith(u));
+    })
+    .filter(feature => feature.feature_type !== 'Feature deprecation')
+    .map(feature => {
+      return {
+        id: feature.id,
+        name: feature.name,
+        statusUrl: `https://chromestatus.com/feature/${feature.id}`,
+        specUrls: [feature.standards.spec]
+      };
+    });
+
+  return mappings;
+}

--- a/src/parse-webkit.js
+++ b/src/parse-webkit.js
@@ -112,3 +112,28 @@ export function getImplementationStatus(key) {
 
   return impl;
 }
+
+
+export function findMappings(shortname, relatedUrls, knownData) {
+  const mappings = ['specification', 'feature']
+    .map(type => {
+      const prop = type === 'feature' ? 'features' : type;
+      return data[prop]
+        .filter(feature => {
+          const url = (feature.url ?? '').replace(/^http:/, 'https:');
+          return url && !!relatedUrls.find(u => url.startsWith(u) | u.startsWith(url));
+        })
+        .map(feature => {
+          const id = type + '-' + feature.name.replace(/ /g, '-').toLowerCase();
+          return {
+            id: id,
+            name: feature.name,
+            statusUrl: `https://webkit.org/status/#${id}`,
+            specUrls: [feature.url]
+          };
+        });
+    })
+    .flat();
+
+  return mappings;
+}

--- a/src/schema/data.json
+++ b/src/schema/data.json
@@ -5,27 +5,86 @@
   "description": "JSON Schema followed by data files in data folder.",
 
   "definitions": {
+    "name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "statusUrl": {
+      "type": "string",
+      "format": "uri"
+    },
+    "specUrls": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "format": "uri"
+      }
+    },
+    "representative": {
+      "type": "boolean"
+    },
+    "manual": {
+      "type": "boolean"
+    },
+    "lastreviewed": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+    },
+
+    "mappingstr": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [ "id" ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "name": { "$ref": "#/definitions/name" },
+          "statusUrl": { "$ref": "#/definitions/statusUrl" },
+          "specUrls": { "$ref": "#/definitions/specUrls" },
+          "representative": { "$ref": "#/definitions/representative" },
+          "manual": { "$ref": "#/definitions/manual" },
+          "lastreviewed": { "$ref": "#/definitions/lastreviewed" }
+        },
+        "minItems": 1
+      }
+    },
+
     "statusref": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "bcd": {
-          "type": "string",
-          "minLength": 1
+          "$ref": "#/definitions/mappingstr"
         },
         "caniuse": {
-          "type": "string",
-          "minLength": 1
+          "$ref": "#/definitions/mappingstr"
         },
         "chrome": {
-          "type": "integer"
-        },
-        "edge": {
-          "type": "string"
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [ "id" ],
+            "properties": {
+              "id": {
+                "type": "integer"
+              },
+              "name": { "$ref": "#/definitions/name" },
+              "statusUrl": { "$ref": "#/definitions/statusUrl" },
+              "specUrls": { "$ref": "#/definitions/specUrls" },
+              "representative": { "$ref": "#/definitions/representative" },
+              "manual": { "$ref": "#/definitions/manual" },
+              "lastreviewed": { "$ref": "#/definitions/lastreviewed" }
+            },
+            "minItems": 1
+          }
         },
         "webkit": {
-          "type": "string",
-          "minLength": 1
+          "$ref": "#/definitions/mappingstr"
         },
         "manual": {
           "type": "array",

--- a/src/schema/index.json
+++ b/src/schema/index.json
@@ -61,19 +61,15 @@
           "partial": {
             "type": "boolean"
           },
-          "features": {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "minLength": 1
-            }
-          },
           "notes": {
             "type": "array",
             "items": {
               "type": "string",
               "minLength": 1
             }
+          },
+          "details": {
+            "$ref": "#/definitions/support"
           }
         }
       }


### PR DESCRIPTION
This major update finds and proposes new possible mappings between specs and entry points in implementation status platforms, matching on spec URLs.

Breaking changes:
- The structure of data files changes to always take objects to describe a mapping and to allow more than one mapping for a spec. This makes the data file slightly less convenient to edit manually, but then the intent is for it to be mainly managed automatically from now on.
- The structure of index files changes slightly to replace the `href` property with a `details` property that lists all individual support information.

README still needs to be updated and job automation still needs to be done!