### PR TITLE
Add script to create mappings PR per data file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+config.json
 node_modules

--- a/src/create-mappings-pr.js
+++ b/src/create-mappings-pr.js
@@ -1,0 +1,176 @@
+/*******************************************************************************
+Helper script that creates a number of pull requests with proposed new mappings
+
+Run with:
+node src/create-mappings-pr.js [nb] --known
+... where [nb] is the maximum number of pull requests to create (5 by default)
+*******************************************************************************/
+
+import esMain from 'es-main';
+import { findMappings } from './find-mappings.js';
+import { Octokit } from './octokit.js';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { execSync } from 'child_process';
+
+const owner = 'w3c';
+const repo = 'browser-statuses';
+
+// Compute __dirname (not exposed when ES6 modules are used)
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+
+/*******************************************************************************
+Retrieve GH_TOKEN from environment, prepare Octokit and kick things off
+*******************************************************************************/
+const GH_TOKEN = (() => {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(process.cwd(), 'config.json'), 'utf8')).GH_TOKEN;
+  } catch {
+    return process.env.GH_TOKEN;
+  }
+})();
+if (!GH_TOKEN) {
+  console.error('GH_TOKEN must be set to some personal access token as an env variable or in a config.json file');
+  process.exit(1);
+}
+
+const octokit = Octokit({
+  auth: GH_TOKEN
+  //log: console
+});
+
+
+function btoa(str) {
+  return Buffer.from(str).toString('base64');
+}
+
+function esc(title) {
+  return (title ?? '').replace(/</g, '&lt;');
+}
+
+async function createMappingsPR(shortname, mappings) {
+  console.log();
+  console.log(`Create mappings PR for "${shortname}"`);
+  console.log('- Get latest commit on current branch');
+  const latestCommitSha = execSync('git log -n 1 --pretty=format:"%H"', { encoding: 'utf8' }).trim();
+  console.log(`- Current branch is at ${latestCommitSha}`);
+
+  console.log('- Look for a pending PR for the shortname');
+  const searchResponse = await octokit.search.issuesAndPullRequests({
+    q: `repo:${owner}/${repo} type:pr state:open head:data-${shortname}-mappings`
+  });
+  const found = searchResponse?.data?.items?.[0];
+
+  const pendingPRResponse = found ?
+    await octokit.pulls.get({
+      owner, repo,
+      pull_number: found.number
+    }) :
+    null;
+  const pendingPR = pendingPRResponse?.data;
+  console.log(pendingPR ?
+    `- Found pending PR for same spec series: ${pendingPR.title} (#${pendingPR.number})` :
+    '- No pending PR for same spec series');
+  if (pendingPR) {
+    return false;
+  }
+
+  console.log('- Update data file');
+  const dataFile = JSON.parse(fs.readFileSync(
+    path.join(__dirname, '..', 'data', `${shortname}.json`),
+    'utf8'));
+  dataFile.statusref = mappings.statusref;
+  const updatedDataFileContents = btoa(JSON.stringify(dataFile, null, 2));
+  console.log(`- Data file updated`);
+
+  console.log('- Prepare PR title and body');
+  const title = `Update platform status references for "${shortname}"`;
+  const body = `
+🤖 This pull request was automatically created to facilitate human review of data changes for the \`data/${shortname}.json\` file.
+
+🧐 Please check the todos below. If all looks good, merge this pull request to release the changes to npm. If changes are needed, push additional commits to this pull request before you merge.
+
+General info about the proposed pull request:
+` + mappings.analysis.info.map(info => `- ${esc(info)}`).join('\n') + `
+
+Changes introduced by the pull request:
+` + mappings.analysis.changes.map(change => `- ${esc(change)}`).join('\n') + `
+
+**Additional things to review:**
+` + mappings.analysis.todo.map(todo => `- [ ] ${esc(todo)}`).join('\n');
+  console.log(`- title: ${title}`);
+
+  const prRef = `data-${shortname}-mappings`;
+  console.log(`- Create new branch ${prRef} for the PR`);
+  await octokit.git.createRef({
+    owner, repo,
+    ref: `refs/heads/${prRef}`,
+    sha: latestCommitSha
+  });
+  
+  console.log('- Commit updated data to PR branch');
+  // TODO: handle case when data file does not exist yet
+  const fileResponse = await octokit.repos.getContent({
+    owner, repo, path: `data/${shortname}.json`
+  });
+
+  const resp = await octokit.repos.createOrUpdateFileContents({
+    owner, repo,
+    branch: prRef,
+    path: `data/${shortname}.json`,
+    message: `Update platform status references for ${shortname}`,
+    content: updatedDataFileContents,
+    sha: fileResponse.data.sha,
+  });
+  
+  console.log('- Actually create PR');
+  const defaultBranchResponse = await octokit.repos.get({ owner, repo });
+  const defaultBranch = defaultBranchResponse.data.default_branch;
+  const prResponse = await octokit.pulls.create({
+    owner, repo,
+    head: prRef,
+    base: defaultBranch,
+    title, body
+  });
+  console.log('- done');
+
+  return true;
+}
+
+async function processMappings(mappings, nb) {
+  const changes = Object.keys(mappings)
+    .filter(shortname => mappings[shortname].analysis.changes.length > 0);
+  let i = 0;
+  for (const shortname of changes) {
+    const created = await createMappingsPR(shortname, mappings[shortname]);
+    if (created) {
+      i += 1;
+    }
+    if (i === nb) {
+      break;
+    }
+  }
+}
+
+
+/*******************************************************************************
+Main loop
+*******************************************************************************/
+if (esMain(import.meta)) {
+  const onlyExistingOnes = !!process.argv.find(arg => arg === '--known');
+  let nb = process.argv.find(arg => arg.match(/^\d+$/));
+  if (nb) {
+    nb = parseInt(nb, 10);
+  }
+  else {
+    nb = 5;
+  }
+  
+  const dataFolder = path.join(__dirname, '..', 'data');
+  findMappings(dataFolder, onlyExistingOnes)
+    .then(mappings => processMappings(mappings, nb))
+    .then(_ => console.log('done'));
+}

--- a/src/find-mappings.js
+++ b/src/find-mappings.js
@@ -47,6 +47,10 @@ function onlyUnique(value, index, self) {
   return self.indexOf(value) === index;
 }
 
+function esc(title) {
+  return (title ?? '').replace(/</g, '&lt;');
+}
+
 function findMappingsForSpec(shortname, relatedSpecs, data) {
   const res = JSON.parse(JSON.stringify(data ?? {}));
   res.statusref = {};
@@ -142,9 +146,9 @@ function findMappingsForSpec(shortname, relatedSpecs, data) {
     // No old mapping. New mappings found.
     // Check which ones are "representative".
     if (!oldref && newref) {
-      analysis.info.push(`${name}: new mappings found`);
+      analysis.info.push(`${name}: mappings found`);
       for (const mapping of newref) {
-        analysis.changes.push(`Add ${name} mapping [${mapping.id}](${mapping.statusUrl})`);
+        analysis.changes.push(`Add ${name} mapping [${mapping.id}](${mapping.statusUrl})${mapping.name && mapping.name !== mapping.id ? ' ' + esc(mapping.name) : ''}`);
       }
       analysis.todo.push(`Check "representative" flags for ${name} mappings`);
     }
@@ -154,7 +158,7 @@ function findMappingsForSpec(shortname, relatedSpecs, data) {
     if (oldref && !newref) {
       analysis.info.push(`${name}: obsolete mappings found`);
       for (const mapping of oldref) {
-        analysis.changes.push(`Drop old ${name} mapping ${mapping.id}`);
+        analysis.changes.push(`Drop old ${name} mapping ${mapping.id}${mapping.name && mapping.name !== mapping.id ? ' ' + esc(mapping.name) : ''}`);
         analysis.todo.push(`Check need to add "manual" flag to keep ${name} mapping ${mapping.id} if needed`)
       }
     }
@@ -165,24 +169,21 @@ function findMappingsForSpec(shortname, relatedSpecs, data) {
     // For new mappings that update old mappings, check new info
     // For new mappings that are the same as old mappings, report but do nothing.
     if (oldref && newref) {
-      if ((oldref.length === newref.length) &&
-          oldref.every(mapping => newref.find(m => m.id === mapping.id))) {
-        analysis.info.push(`${name}: same mappings as before`);
-      }
-      else {
-        analysis.info.push(`${name}: other mappings found`);
+      if ((oldref.length !== newref.length) ||
+          oldref.find(mapping => !newref.find(m => m.id === mapping.id))) {
+        analysis.info.push(`${name}: additional mappings found`);
       }
 
       for (const mapping of oldref) {
         if (!newref.find(m => m.id === mapping.id)) {
-          analysis.changes.push(`Drop old ${name} mapping ${mapping.id}`);
+          analysis.changes.push(`Drop old ${name} mapping ${mapping.id}${mapping.name && mapping.name !== mapping.id ? ' ' + esc(mapping.name) : ''}`);
           analysis.todo.push(`Check need to add "manual" flag to keep ${name} mapping ${mapping.id} if needed`)
         }
       }
 
       for (const mapping of newref) {
         if (!oldref.find(m => m.id === mapping.id)) {
-          analysis.changes.push(`Add ${name} mapping [${mapping.id}](${mapping.statusUrl})`);
+          analysis.changes.push(`Add ${name} mapping [${mapping.id}](${mapping.statusUrl})${mapping.name && mapping.name !== mapping.id ? ' ' + esc(mapping.name) : ''}`);
         }
         analysis.todo.push(`Check "representative" flags for ${name} mappings`);
       }
@@ -192,7 +193,7 @@ function findMappingsForSpec(shortname, relatedSpecs, data) {
         if (!oldmapping) {
           continue;
         }
-        analysis.info.push(`Same ${name} mapping [${mapping.id}](${mapping.statusUrl}) as before`);
+        analysis.info.push(`${name}: same mapping [${mapping.id}](${mapping.statusUrl}) as before`);
       }
     }
   }

--- a/src/octokit.js
+++ b/src/octokit.js
@@ -1,0 +1,39 @@
+/**
+ * Wrapper around Octokit to add throttling and avoid hitting rate limits
+ */
+
+import { throttling } from '@octokit/plugin-throttling';
+import { Octokit as rawOctokit } from '@octokit/rest';
+
+const throttledOctokit = rawOctokit.plugin(throttling);
+
+const MAX_RETRIES = 3;
+
+export function Octokit(params) {
+  params = params || {};
+
+  const octoParams = Object.assign({
+    throttle: {
+      onRateLimit: (retryAfter, options) => {
+        if (options.request.retryCount < MAX_RETRIES) {
+          console.warn(`Rate limit exceeded, retrying after ${retryAfter} seconds`)
+          return true;
+        } else {
+          console.error(`Rate limit exceeded, giving up after ${MAX_RETRIES} retries`);
+          return false;
+        }
+      },
+      onSecondaryRateLimit: (retryAfter, options) => {
+        if (options.request.retryCount < MAX_RETRIES) {
+          console.warn(`Abuse detection triggered, retrying after ${retryAfter} seconds`)
+          return true;
+        } else {
+          console.error(`Abuse detection triggered, giving up after ${MAX_RETRIES} retries`);
+          return false;
+        }
+      }
+    }
+  }, params);
+
+  return new throttledOctokit(octoParams);
+}


### PR DESCRIPTION
The `create-mappings-pr.js` script proposes new mappings in separate pull requests, one per data file. The description of the pull request details the actual changes, and suggests additional things to review (notably the need to look at `representative` flags.

The script creates up to 5 pull requests by default.

A GitHub token needs to be available as a `GH_TOKEN` environment variable or within a `config.json` file.