### PR TITLE
Add features referenced in web-roadmaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@ The implementation status for the spec or feature. Value may be one of:
 - `"consideration"`: support for the spec or feature is under consideration but
 not under active developement.
 - `"notsupported"`: spec or feature is not supported in the browser.
+- `""` (only when implementation info was entered manually): implementation status reported by platform status projects is incorrect. Actual implementation status is unknown.
 
 The `status` property is always set.
 

--- a/data/ambient-light.json
+++ b/data/ambient-light.json
@@ -56,6 +56,22 @@
         ],
         "representative": true
       }
+    ],
+    "manual": [
+      {
+        "ua": "firefox",
+        "status": "notsupported",
+        "source": "feedback",
+        "date": "2018-03-16",
+        "comment": "The version based on the Generic Sensor API is not what is shipping in Firefox, see https://github.com/w3c/web-roadmaps/issues/160"
+      },
+      {
+        "ua": "firefox_android",
+        "status": "notsupported",
+        "source": "feedback",
+        "date": "2018-03-16",
+        "comment": "The version based on the Generic Sensor API is not what is shipping in Firefox, see https://github.com/w3c/web-roadmaps/issues/160"
+      }
     ]
   }
 }

--- a/data/audio-output.json
+++ b/data/audio-output.json
@@ -7,7 +7,8 @@
         "statusUrl": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/setSinkId",
         "specUrls": [
           "https://w3c.github.io/mediacapture-output/#dom-htmlmediaelement-setsinkid"
-        ]
+        ],
+        "representative": true
       },
       {
         "id": "api.HTMLMediaElement.sinkId",
@@ -15,7 +16,8 @@
         "statusUrl": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/sinkId",
         "specUrls": [
           "https://w3c.github.io/mediacapture-output/#dom-htmlmediaelement-sinkid"
-        ]
+        ],
+        "representative": true
       },
       {
         "id": "api.MediaDevices.selectAudioOutput",
@@ -23,7 +25,8 @@
         "statusUrl": "https://developer.mozilla.org/docs/Web/API/MediaDevices/selectAudioOutput",
         "specUrls": [
           "https://w3c.github.io/mediacapture-output/#dom-mediadevices-selectaudiooutput"
-        ]
+        ],
+        "representative": true
       },
       {
         "id": "api.Permissions.speaker-selection_permission",

--- a/data/css-backgrounds.json
+++ b/data/css-backgrounds.json
@@ -1,4 +1,54 @@
 {
+  "features": {
+    "border-radius": {
+      "url": "https://drafts.csswg.org/css-backgrounds/#border-radius",
+      "title": "Rounded corners",
+      "statusref": {
+        "bcd": [
+          {
+            "id": "css.properties.border-bottom-left-radius"
+          },
+          {
+            "id": "css.properties.border-bottom-right-radius"
+          },
+          {
+            "id": "css.properties.border-radius",
+            "representative": true
+          },
+          {
+            "id": "css.properties.border-top-left-radius"
+          },
+          {
+            "id": "css.properties.border-top-right-radius"
+          }
+        ],
+        "caniuse": [
+          {
+            "id": "border-radius",
+            "representative": true
+          }
+        ]
+      }
+    },
+    "box-shadow": {
+      "url": "https://drafts.csswg.org/css-backgrounds/#box-shadow",
+      "title": "Box shadow effects",
+      "statusref": {
+        "bcd": [
+          {
+            "id": "css.properties.box-shadow",
+            "representative": true
+          }
+        ],
+        "caniuse": [
+          {
+            "id": "css-boxshadow",
+            "representative": true
+          }
+        ]
+      }
+    }
+  },
   "statusref": {
     "bcd": [
       {

--- a/data/css-fonts.json
+++ b/data/css-fonts.json
@@ -83,6 +83,36 @@
           }
         ]
       }
+    },
+    "font-display": {
+      "url": "https://drafts.csswg.org/css-fonts-4/#font-display-desc",
+      "title": "font-display property",
+      "statusref": {
+        "bcd": [
+          {
+            "id": "css.at-rules.font-face.font-display",
+            "representative": true
+          }
+        ],
+        "caniuse": [
+          {
+            "id": "css-font-rendering-controls",
+            "representative": true
+          }
+        ],
+        "chrome": [
+          {
+            "id": 4799947908055040,
+            "representative": true
+          }
+        ],
+        "webkit": [
+          {
+            "id": "specification-css-font-display",
+            "representative": true
+          }
+        ]
+      }
     }
   },
   "statusref": {

--- a/data/css-nav.json
+++ b/data/css-nav.json
@@ -1,0 +1,8 @@
+{
+  "polyfills": [
+    {
+      "label": "Spatial Navigation Polyfill",
+      "url": "https://github.com/WICG/spatial-navigation/tree/main/polyfill"
+    }
+  ]
+}

--- a/data/css-scoping.json
+++ b/data/css-scoping.json
@@ -57,7 +57,8 @@
         "statusUrl": "https://developer.mozilla.org/docs/Web/CSS/:host",
         "specUrls": [
           "https://drafts.csswg.org/css-scoping/#host-selector"
-        ]
+        ],
+        "representative": true
       },
       {
         "id": "css.selectors.host-context",
@@ -65,7 +66,8 @@
         "statusUrl": "https://developer.mozilla.org/docs/Web/CSS/:host-context()",
         "specUrls": [
           "https://drafts.csswg.org/css-scoping/#host-selector"
-        ]
+        ],
+        "representative": true
       },
       {
         "id": "css.selectors.hostfunction",
@@ -73,7 +75,8 @@
         "statusUrl": "https://developer.mozilla.org/docs/Web/CSS/:host()",
         "specUrls": [
           "https://drafts.csswg.org/css-scoping/#host-selector"
-        ]
+        ],
+        "representative": true
       },
       {
         "id": "css.selectors.slotted",
@@ -81,7 +84,8 @@
         "statusUrl": "https://developer.mozilla.org/docs/Web/CSS/::slotted",
         "specUrls": [
           "https://drafts.csswg.org/css-scoping/#slotted-pseudo"
-        ]
+        ],
+        "representative": true
       }
     ],
     "chrome": [

--- a/data/css-sizing.json
+++ b/data/css-sizing.json
@@ -1,4 +1,24 @@
 {
+  "features": {
+    "box-sizing": {
+      "url": "https://drafts.csswg.org/css-sizing/#box-sizing",
+      "title": "box-sizing property",
+      "statusref": {
+        "bcd": [
+          {
+            "id": "css.properties.box-sizing",
+            "representative": true
+          }
+        ],
+        "caniuse": [
+          {
+            "id": "css3-boxsizing",
+            "representative": true
+          }
+        ]
+      }
+    }
+  },
   "statusref": {
     "bcd": [
       {

--- a/data/css-values.json
+++ b/data/css-values.json
@@ -1,4 +1,24 @@
 {
+  "features": {
+    "viewport-relative-lengths": {
+      "url": "https://www.w3.org/TR/css-values/#viewport-relative-lengths",
+      "title": "viewport-perfcentage lengths",
+      "statusref": {
+        "caniuse": [
+          {
+            "id": "viewport-units",
+            "representative": true
+          }
+        ],
+        "webkit": [
+          {
+            "id": "feature-css-viewport-relative-units",
+            "representative": true
+          }
+        ]
+      }
+    }
+  },
   "statusref": {
     "bcd": [
       {

--- a/data/dom.json
+++ b/data/dom.json
@@ -23,6 +23,30 @@
           }
         ]
       }
+    },
+    "addeventlistener-passive": {
+      "url": "https://dom.spec.whatwg.org/#dom-addeventlisteneroptions-passive",
+      "title": "Passive event listeners",
+      "statusref": {
+        "bcd": [
+          {
+            "id": "api.EventTarget.addEventListener.options_parameter.options_passive_parameter",
+            "representative": true
+          }
+        ],
+        "caniuse": [
+          {
+            "id": "passive-event-listener",
+            "representative": true
+          }
+        ],
+        "chrome": [
+          {
+            "id": 5745543795965952,
+            "representative": true
+          }
+        ]
+      }
     }
   },
   "statusref": {

--- a/data/geolocation-sensor.json
+++ b/data/geolocation-sensor.json
@@ -1,0 +1,8 @@
+{
+  "polyfills": [
+      {
+        "label": "sensor-polyfills",
+        "url": "https://github.com/kenchris/sensor-polyfills"
+      }
+  ]
+}

--- a/data/html.json
+++ b/data/html.json
@@ -1,5 +1,120 @@
 {
   "features": {
+    "autocomplete": {
+      "url": "https://html.spec.whatwg.org/multipage/#autofilling-form-controls:-the-autocomplete-attribute",
+      "title": "autocomplete attribute",
+      "statusref": {
+        "bcd": [
+          {
+            "id": "api.HTMLFormElement.autocomplete",
+            "representative": true
+          },
+          {
+            "id": "api.HTMLInputElement.autocomplete",
+            "representative": true
+          },
+          {
+            "id": "api.HTMLSelectElement.autocomplete",
+            "representative": true
+          },
+          {
+            "id": "api.HTMLTextAreaElement.autocomplete",
+            "representative": true
+          },
+          {
+            "id": "html.global_attributes.autocomplete",
+            "representative": true
+          }
+        ],
+        "caniuse": [
+          {
+            "id": "input-autocomplete-onoff"
+          }
+        ],
+        "chrome": [
+          {
+            "id": 5680387573415936,
+            "representative": true
+          }
+        ]
+      }
+    },
+    "browsing-context": {
+      "url": "https://html.spec.whatwg.org/multipage/browsers.html#windows",
+      "title": "browsing context"
+    },
+    "eventsource": {
+      "url": "https://html.spec.whatwg.org/multipage/server-sent-events.html#the-eventsource-interface",
+      "title": "Server-sent events",
+      "statusref": {
+        "bcd": [
+          {
+            "id": "api.EventSource",
+            "representative": true
+          },
+          {
+            "id": "api.EventSource.EventSource"
+          },
+          {
+            "id": "api.EventSource.close"
+          },
+          {
+            "id": "api.EventSource.error_event"
+          },
+          {
+            "id": "api.EventSource.message_event"
+          },
+          {
+            "id": "api.EventSource.open_event"
+          },
+          {
+            "id": "api.EventSource.readyState"
+          },
+          {
+            "id": "api.EventSource.url"
+          },
+          {
+            "id": "api.EventSource.withCredentials"
+          }
+        ],
+        "caniuse": [
+          {
+            "id": "eventsource",
+            "representative": true
+          }
+        ],
+        "chrome": [
+          {
+            "id": 5311740673785856,
+            "representative": true
+          }
+        ]
+      }
+    },
+    "inputmode": {
+      "url": "https://html.spec.whatwg.org/multipage/interaction.html#attr-inputmode",
+      "title": "inputmode attribute",
+      "statusref": {
+        "bcd": [
+          {
+            "id": "html.global_attributes.inputmode",
+            "representative": true
+          }
+        ],
+        "caniuse": [
+          {
+            "id": "input-inputmode",
+            "representative": true
+          }
+        ],
+        "chrome": [
+          {
+            "id": 6225984592281600,
+            "representative": true
+          }
+        ]
+      }
+    },
     "template": {
       "url": "https://html.spec.whatwg.org/multipage/#the-template-element",
       "title": "The template element",

--- a/data/html.json
+++ b/data/html.json
@@ -14147,14 +14147,6 @@
         ]
       },
       {
-        "id": "forms",
-        "name": "HTML5 form features",
-        "statusUrl": "https://caniuse.com/forms",
-        "specUrls": [
-          "https://html.spec.whatwg.org/multipage/forms.html#forms"
-        ]
-      },
-      {
         "id": "hardwareconcurrency",
         "name": "navigator.hardwareConcurrency",
         "statusUrl": "https://caniuse.com/hardwareconcurrency",

--- a/data/manifest-app-info.json
+++ b/data/manifest-app-info.json
@@ -7,7 +7,8 @@
         "statusUrl": "https://developer.mozilla.org/docs/Web/Manifest/categories",
         "specUrls": [
           "https://w3c.github.io/manifest-app-info/#categories-member"
-        ]
+        ],
+        "representative": true
       },
       {
         "id": "html.manifest.description",
@@ -15,7 +16,8 @@
         "statusUrl": "https://developer.mozilla.org/docs/Web/Manifest/description",
         "specUrls": [
           "https://w3c.github.io/manifest-app-info/#description-member"
-        ]
+        ],
+        "representative": true
       },
       {
         "id": "html.manifest.iarc_rating_id",
@@ -23,7 +25,8 @@
         "statusUrl": "https://developer.mozilla.org/docs/Web/Manifest/iarc_rating_id",
         "specUrls": [
           "https://w3c.github.io/manifest-app-info/#iarc_rating_id-member"
-        ]
+        ],
+        "representative": true
       },
       {
         "id": "html.manifest.screenshots",
@@ -31,7 +34,8 @@
         "statusUrl": "https://developer.mozilla.org/docs/Web/Manifest/screenshots",
         "specUrls": [
           "https://w3c.github.io/manifest-app-info/#screenshots-member"
-        ]
+        ],
+        "representative": true
       }
     ],
     "chrome": [

--- a/data/mediaqueries.json
+++ b/data/mediaqueries.json
@@ -408,6 +408,130 @@
           }
         ]
       }
+    },
+    "color-gamut": {
+      "url": "https://drafts.csswg.org/mediaqueries/#color-gamut",
+      "title": "color-gamut media query",
+      "statusref": {
+        "bcd": [
+          {
+            "id": "css.at-rules.media.color-gamut",
+            "representative": true
+          }
+        ],
+        "chrome": [
+          {
+            "id": 5354410980933632,
+            "representative": true
+          }
+        ]
+      }
+    },
+    "pointer": {
+      "title": "pointer feature",
+      "url": "https://drafts.csswg.org/mediaqueries/#pointer",
+      "statusref": {
+        "bcd": [
+          {
+            "id": "css.at-rules.media.pointer",
+            "representative": true
+          }
+        ],
+        "caniuse": [
+          {
+            "id": "css-media-interaction",
+            "representative": true
+          }
+        ]
+      }
+    },
+    "hover": {
+      "title": "hover feature",
+      "url": "https://drafts.csswg.org/mediaqueries/#hover",
+      "statusref": {
+        "bcd": [
+          {
+            "id": "css.at-rules.media.hover",
+            "representative": true
+          }
+        ],
+        "caniuse": [
+          {
+            "id": "css-media-interaction",
+            "representative": true
+          }
+        ]
+      }
+    },
+    "prefers-reduced-motion": {
+      "title": "prefers-reduced-motion feature",
+      "url": "https://drafts.csswg.org/mediaqueries/#prefers-reduced-motion",
+      "statusref": {
+        "bcd": [
+          {
+            "id": "css.at-rules.media.prefers-reduced-motion",
+            "representative": true
+          }
+        ],
+        "caniuse": [
+          {
+            "id": "prefers-reduced-motion",
+            "representative": true
+          }
+        ],
+        "chrome": [
+          {
+            "id": 5597964353404928,
+            "representative": true
+          }
+        ]
+      }
+    },
+    "prefers-color-scheme": {
+      "title": "prefers-color-scheme feature",
+      "url": "https://drafts.csswg.org/mediaqueries/#prefers-color-scheme",
+      "statusref": {
+        "bcd": [
+          {
+            "id": "css.at-rules.media.prefers-color-scheme",
+            "representative": true
+          }
+        ],
+        "caniuse": [
+          {
+            "id": "prefers-color-scheme",
+            "representative": true
+          }
+        ],
+        "chrome": [
+          {
+            "id": 5109758977638400,
+            "representative": true
+          }
+        ]
+      }
+    },
+    "prefers-contrast": {
+      "title": "prefers-contrast",
+      "url": "https://drafts.csswg.org/mediaqueries/#prefers-contrast",
+      "statusref": {
+        "bcd": [
+          {
+            "id": "css.at-rules.media.prefers-contrast",
+            "representative": true
+          }
+        ],
+        "chrome": [
+          {
+            "id": 5646323212615680,
+            "representative": true
+          }
+        ]
+      }
+    },
+    "level-5": {
+      "title": "Level 5",
+      "url": "https://drafts.csswg.org/mediaqueries-5/"
     }
   }
 }

--- a/data/pointerevents.json
+++ b/data/pointerevents.json
@@ -1,4 +1,30 @@
 {
+  "features": {
+    "touch-action": {
+      "url": "https://w3c.github.io/pointerevents/#the-touch-action-css-property",
+      "title": "touch-action property",
+      "statusref": {
+        "bcd": [
+          {
+            "id": "css.properties.touch-action",
+            "representative": true
+          }
+        ],
+        "caniuse": [
+          {
+            "id": "css-touch-action",
+            "representative": true
+          }
+        ],
+        "chrome": [
+          {
+            "id": 5912074022551552,
+            "representative": true
+          }
+        ]
+      }
+    }
+  },
   "statusref": {
     "bcd": [
       {
@@ -442,8 +468,7 @@
         "specUrls": [
           "https://compat.spec.whatwg.org/#touch-action",
           "https://w3c.github.io/pointerevents/#the-touch-action-css-property"
-        ],
-        "representative": true
+        ]
       }
     ],
     "caniuse": [
@@ -453,8 +478,7 @@
         "statusUrl": "https://caniuse.com/css-touch-action",
         "specUrls": [
           "https://www.w3.org/TR/pointerevents/#the-touch-action-css-property"
-        ],
-        "representative": true
+        ]
       },
       {
         "id": "pointer",
@@ -462,7 +486,8 @@
         "statusUrl": "https://caniuse.com/pointer",
         "specUrls": [
           "https://www.w3.org/TR/pointerevents/"
-        ]
+        ],
+        "representative": true
       }
     ],
     "chrome": [
@@ -472,7 +497,8 @@
         "statusUrl": "https://chromestatus.com/feature/4504699138998272",
         "specUrls": [
           "http://www.w3.org/TR/pointerevents/"
-        ]
+        ],
+        "representative": true
       },
       {
         "id": 5088301178421248,
@@ -544,8 +570,7 @@
         "statusUrl": "https://chromestatus.com/feature/5912074022551552",
         "specUrls": [
           "https://dvcs.w3.org/hg/pointerevents/raw-file/tip/pointerEvents.html#the-touch-action-css-property"
-        ],
-        "representative": true
+        ]
       },
       {
         "id": 6041426311774208,
@@ -563,7 +588,8 @@
         "statusUrl": "https://webkit.org/status/#specification-pointer-events-level-2",
         "specUrls": [
           "https://www.w3.org/TR/pointerevents/"
-        ]
+        ],
+        "representative": true
       }
     ]
   },

--- a/data/proximity.json
+++ b/data/proximity.json
@@ -20,6 +20,22 @@
           "https://www.w3.org/TR/proximity/"
         ]
       }
+    ],
+    "manual": [
+      {
+        "ua": "firefox",
+        "status": "",
+        "source": "feedback",
+        "date": "2018-03-19",
+        "comment": "The version based on the Generic Sensor API is not what is shipping in Firefox, see https://github.com/w3c/web-roadmaps/issues/160"
+      },
+      {
+        "ua": "firefox_android",
+        "status": "",
+        "source": "feedback",
+        "date": "2018-03-19",
+        "comment": "The version based on the Generic Sensor API is not what is shipping in Firefox, see https://github.com/w3c/web-roadmaps/issues/160"
+      }
     ]
   }
 }

--- a/data/resource-hints.json
+++ b/data/resource-hints.json
@@ -64,16 +64,20 @@
   "statusref": {
     "caniuse": [
       {
-        "id": "link-rel-dns-prefetch"
+        "id": "link-rel-dns-prefetch",
+        "representative": true
       },
       {
-        "id": "link-rel-preconnect"
+        "id": "link-rel-preconnect",
+        "representative": true
       },
       {
-        "id": "link-rel-prefetch"
+        "id": "link-rel-prefetch",
+        "representative": true
       },
       {
-        "id": "link-rel-prerender"
+        "id": "link-rel-prerender",
+        "representative": true
       }
     ],
     "chrome": [

--- a/data/scheduling-apis.json
+++ b/data/scheduling-apis.json
@@ -1,4 +1,28 @@
 {
+  "features": {
+    "postTask": {
+      "url": "https://wicg.github.io/scheduling-apis/#dom-scheduler-posttask",
+      "title": "scheduler.postTask()",
+      "statusref": {
+        "bcd": [
+          {
+            "id": "api.Scheduler.postTask",
+            "representative": true
+          }
+        ],
+        "chrome": [
+          {
+            "id": 6031161734201344,
+            "representative": true
+          }
+        ]
+      }
+    },
+    "yield": {
+      "url": "https://github.com/WICG/main-thread-scheduling/blob/master/YieldAndContinuation.md",
+      "title": "scheduler.yield()"
+    }
+  },
   "statusref": {
     "bcd": [
       {

--- a/data/speech-api.json
+++ b/data/speech-api.json
@@ -1,4 +1,42 @@
 {
+  "features": {
+    "recognition": {
+      "title": "Speech recognition",
+      "url": "https://w3c.github.io/speech-api/speechapi.html#speechreco-section",
+      "statusref": {
+        "caniuse": [
+          {
+            "id": "speech-recognition",
+            "representative": true
+          }
+        ],
+        "chrome": [
+          {
+            "id": 5908775487668224,
+            "representative": true
+          }
+        ]
+      }
+    },
+    "synthesis": {
+      "title": "Speech synthesis",
+      "url": "https://w3c.github.io/speech-api/speechapi.html#tts-section",
+      "statusref": {
+        "caniuse": [
+          {
+            "id": "speech-synthesis",
+            "representative": true
+          }
+        ],
+        "chrome": [
+          {
+            "id": 4782875580825600,
+            "representative": true
+          }
+        ]
+      }
+    }
+  },
   "statusref": {
     "bcd": [
       {
@@ -745,7 +783,8 @@
         "statusUrl": "https://caniuse.com/speech-synthesis",
         "specUrls": [
           "https://w3c.github.io/speech-api/speechapi.html#tts-section"
-        ]
+        ],
+        "representative": true
       }
     ],
     "chrome": [
@@ -755,7 +794,8 @@
         "statusUrl": "https://chromestatus.com/feature/4782875580825600",
         "specUrls": [
           "https://w3c.github.io/speech-api/"
-        ]
+        ],
+        "representative": true
       },
       {
         "id": 4818803819020288,

--- a/data/storage-access.json
+++ b/data/storage-access.json
@@ -10,12 +10,14 @@
       {
         "id": "api.Document.hasStorageAccess",
         "manual": true,
-        "lastreviewed": "2022-06-05"
+        "lastreviewed": "2022-06-05",
+        "representative": true
       },
       {
         "id": "api.Document.requestStorageAccess",
         "manual": true,
-        "lastreviewed": "2022-06-05"
+        "lastreviewed": "2022-06-05",
+        "representative": true
       }
     ]
   },

--- a/src/build-index.js
+++ b/src/build-index.js
@@ -320,7 +320,14 @@ export async function extractImplData(files) {
   // Loop through files and compute the implementation status for each of them
   const impldata = files.map(file => {
     const id = file.split(/\/|\\/).pop().split('.')[0];
-    const spec = JSON.parse(fs.readFileSync(file, 'utf8'));
+    let spec;
+    try {
+      spec = JSON.parse(fs.readFileSync(file, 'utf8'));
+    }
+    catch (err) {
+      console.error(`Could not parse ${file} as JSON`);
+      throw err;
+    }
 
     // Get implementation status for the whole spec
     const implstatus = {

--- a/src/schema/data.json
+++ b/src/schema/data.json
@@ -103,7 +103,7 @@
               },
               "status": {
                 "type": "string",
-                "enum": ["notsupported", "consideration", "indevelopment", "experimental", "shipped"]
+                "enum": ["", "notsupported", "consideration", "indevelopment", "experimental", "shipped"]
               },
               "source": {
                 "type": "string",

--- a/src/schema/index.json
+++ b/src/schema/index.json
@@ -31,7 +31,7 @@
 
           "status": {
             "type": "string",
-            "enum": ["notsupported", "consideration", "indevelopment", "experimental", "shipped"]
+            "enum": ["", "notsupported", "consideration", "indevelopment", "experimental", "shipped"]
           },
           "source": {
             "type": "string",


### PR DESCRIPTION
This adds a series of spec features that web roadmaps talk about. This also adds missing "manual" entries for some of the specs and the possibility to have an empty string status to mean "we don't know but we know that other status values returned by status platforms are wrong".